### PR TITLE
코드 수정 및 Restdocs 수정 작업

### DIFF
--- a/backend/src/docs/asciidoc/api-document.adoc
+++ b/backend/src/docs/asciidoc/api-document.adoc
@@ -44,7 +44,6 @@ include::{snippets}/로그인/http-response.adoc[]
 ==== 요청
 
 include::{snippets}/로그아웃/http-request.adoc[]
-include::{snippets}/로그아웃/request-headers.adoc[]
 
 ==== 응답
 

--- a/backend/src/main/java/com/daily/daily/auth/config/CorsConfig.java
+++ b/backend/src/main/java/com/daily/daily/auth/config/CorsConfig.java
@@ -30,7 +30,7 @@ public class CorsConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://localhost:3000"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("*"));

--- a/backend/src/main/java/com/daily/daily/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/daily/daily/auth/controller/AuthController.java
@@ -31,15 +31,15 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<CommonResponseDTO> logout(@RequestHeader(JwtUtil.ACCESS_HEADER) String accessToken,
-                       @RequestHeader(JwtUtil.REFRESH_HEADER) String refreshToken) {
+    public ResponseEntity<CommonResponseDTO> logout(@CookieValue("AccessToken") String accessToken,
+                       @CookieValue("RefreshToken") String refreshToken) {
 
         authService.logout(TokenDTO.of(accessToken, refreshToken));
         return ResponseEntity.ok().body(new CommonResponseDTO(true, HttpStatus.OK.value()));
     }
 
     @PostMapping("/token")
-    public TokenDTO getToken(@RequestBody RefreshToken refreshToken) {
+    public TokenDTO getToken(@CookieValue("RefreshToken") RefreshToken refreshToken) {
         return new TokenDTO(tokenService.createAccessToken(refreshToken), refreshToken.getRefreshToken());
     }
 }

--- a/backend/src/main/java/com/daily/daily/auth/jwt/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/daily/daily/auth/jwt/JwtAuthorizationFilter.java
@@ -4,9 +4,9 @@ import com.daily.daily.auth.dto.JwtClaimDTO;
 import com.daily.daily.common.dto.ExceptionResponseDTO;
 import com.daily.daily.member.constant.MemberRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +19,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
-
-import static com.daily.daily.auth.jwt.JwtUtil.BEARER_PREFIX;
 
 @Component
 @RequiredArgsConstructor
@@ -32,14 +31,24 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String authHeader = request.getHeader("Authorization");
-
-        if (!hasValidAuthHeader(authHeader)) {
+        Cookie[] authCookies = request.getCookies();
+        if(authCookies == null)
+        {
+            writeErrorResponse(response);
             filterChain.doFilter(request, response);
             return;
         }
 
-        String accessToken = authHeader.substring(BEARER_PREFIX.length());
+        String accessToken = Arrays.stream(authCookies)
+                .filter(name -> name.getName().equals("AccessToken"))
+                .findFirst()
+                .get()
+                .getValue();
+
+        if (!hasValidAuthCookie(accessToken)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         if (!jwtUtil.validateToken(accessToken)) {
             writeErrorResponse(response);
@@ -51,8 +60,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private boolean hasValidAuthHeader(String authHeader) {
-        return StringUtils.hasText(authHeader) && authHeader.startsWith(BEARER_PREFIX);
+    private boolean hasValidAuthCookie(String authCookie) {
+        return StringUtils.hasText(authCookie);
     }
 
     private void writeErrorResponse(HttpServletResponse response) throws IOException {

--- a/backend/src/main/java/com/daily/daily/auth/jwt/JwtUtil.java
+++ b/backend/src/main/java/com/daily/daily/auth/jwt/JwtUtil.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.daily.daily.auth.dto.JwtClaimDTO;
 import com.daily.daily.member.constant.MemberRole;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SecurityException;
@@ -117,8 +118,9 @@ public class JwtUtil {
     private ResponseCookie createTokenCookie(String cookieName, String token) {
         return ResponseCookie.from(cookieName, token)
                 .path("/")
-                .secure(false)
-                .httpOnly(false)
+                .secure(true)
+                .httpOnly(true)
+                .sameSite("None")
                 .build();
     }
 }

--- a/backend/src/main/java/com/daily/daily/member/controller/MemberController.java
+++ b/backend/src/main/java/com/daily/daily/member/controller/MemberController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/member")
+@RequestMapping("/api/members")
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;

--- a/backend/src/main/java/com/daily/daily/oauth/handler/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/daily/daily/oauth/handler/OAuth2SuccessHandler.java
@@ -29,7 +29,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
             jwtUtil.setTokensInCookie(response, accessToken, refreshToken);
 
-            response.sendRedirect("http://localhost:3000");
+            response.sendRedirect("https://localhost:3000");
         } catch (Exception e) {
             log.error("OAuth2 Login 성공 후 예외 발생 : {}", e.getMessage());
         }

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -510,6 +510,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMCwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA0OTU1NzAxfQ.LTFRUqb3bE-g9TGveMVaC0PcRtWaj8-slGVsLwEfBxTkO9aiwLLDk1gYSEe3oGK1wtWlFXu87tJJEBlgbeSKjw
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTAsImlhdCI6MTcwNDk1MjEwMSwiZXhwIjoxNzA2MTYxNzAxfQ.WZlj4WtwHDMoCw746NS5QFbMnnWh4rjYfhw3bcDl7zEaXxpCIqp4E0z2vkMwF6N2G4gTyK-KOGIsrdvSQ_E1yA
 
 {
   "username" : "testtest",
@@ -553,8 +555,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxNCwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA0Njk2NjY4fQ.leflqpEQAQblroNHfxAWJxvQyU2Fk1RMqLR2wJ2aTqQWzLEGXobPi7C0kqvXWz7ke2WB7XcDNnNAiSBEVHMwNw; Path=/; Secure
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTQsImlhdCI6MTcwNDY5MzA2OCwiZXhwIjoxNzA1OTAyNjY4fQ.41uxpfA4rebfxrgv-qN7ion0FM951WTZWheu5E_X3GqgD0aLXNAqgIHcn5tFVqno078ivS9dfvW2T1zlZSTbhg; Path=/; Secure
+Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMCwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA0OTU1NzAyfQ.9OCm53OG5G4NO1r6r1SBpJVPj5p219bomme06oIDH9DNkvaED8DZa_2WdD4qDL0wiebOskhGAzZT-UHcHNsbhA; Path=/
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTAsImlhdCI6MTcwNDk1MjEwMiwiZXhwIjoxNzA2MTYxNzAyfQ.MZk-g07ORmWZicXX1N2My_ythr8AVjMNPyhSr9qxOGsY8pvSve2bWPpwwWGAn16jMvwrEIgt40emDTkpAe0f4g; Path=/
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -573,32 +575,10 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/logout HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDQ2OTY2NjZ9.yYEiZizAwoMTuJ1Yr9sd5LT2HE_MlgU12aglutTEYZNTWdIL6tIWnRlkdL07JtBwocHSbY7eknX31E0NnyCxNQ
-Authorization-refresh: eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA0NjkzMDY3LCJleHAiOjE3MDU5MDI2Njd9.kxmV95k03LEg_lYDf-2BmrTTHaTnjQ_bBhiihX0c9yV55_QlFgT82wVHk7Gl_i0cA34kIiF929HmAQNLfjtMLQ</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDQ5NTU3MDB9.UmAsr1ejyf5EqNEEQUKPotOg7WNoQqLxB114w7Ke__8mmdM2i1e1NA2qaj8itV-LoYZl9d81CJ_lMcuxjazVFQ
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA0OTUyMTAwLCJleHAiOjE3MDYxNjE3MDB9.llz07LesDURF66nlpXG0hvKDOl0NPGbDAQkXpsVwht1-tjodT5X2UnnbEAj0b_CBsWR_kfmhZuKn9mufWxeLWA</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization-refresh</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">refreshToken</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 <div class="sect3">
 <h4 id="_응답_2">응답</h4>
@@ -623,10 +603,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/token HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-
-{
-  "refreshToken" : "eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6OCwiaWF0IjoxNzA0NjkzMDY3LCJleHAiOjE3MDU5MDI2Njd9.UpIek0hVJ2NbpGFbY1VLNohbC4RGOPlfQA7bjDv71R11potlow6B0qXjgtgbPE2tUxMxfXoadnVdZM0OaTj_gA"
-}</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo0LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDQ5NTU3MDF9.kd-pzx1Gf5dNLcdLu869S8fzDHLwA8XZaW20vZJcgDoYrr3Wcp6w0xQItWnrcLcs6kJV7JvCAga665dkY4FMdA
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzA0OTUyMTAxLCJleHAiOjE3MDYxNjE3MDF9.-tz-iJRT6xw2ThZZ0D1EHW4Im-uUlBo37jRIUJXKZ3PVr6GeC0M_1Wm2Q6QWADZSpwu-QvqeYNfZM5kEUl0s9g</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -662,8 +640,8 @@ Content-Type: application/json;charset=UTF-8
 Content-Type: application/json;charset=UTF-8
 
 {
-  "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo4LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDQ2OTY2Njd9.k8-cJ9GC-jvAxPt-JYZQc9LzgvXiWEcyZLIgs0z_8IvXs0dCImBN2ukOAhJNcr8ECnc1bdbPIXKN3OtELW423A",
-  "refreshToken" : "eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6OCwiaWF0IjoxNzA0NjkzMDY3LCJleHAiOjE3MDU5MDI2Njd9.UpIek0hVJ2NbpGFbY1VLNohbC4RGOPlfQA7bjDv71R11potlow6B0qXjgtgbPE2tUxMxfXoadnVdZM0OaTj_gA"
+  "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo0LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDQ5NTU3MDF9.kd-pzx1Gf5dNLcdLu869S8fzDHLwA8XZaW20vZJcgDoYrr3Wcp6w0xQItWnrcLcs6kJV7JvCAga665dkY4FMdA",
+  "refreshToken" : "eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzA0OTUyMTAxLCJleHAiOjE3MDYxNjE3MDF9.-tz-iJRT6xw2ThZZ0D1EHW4Im-uUlBo37jRIUJXKZ3PVr6GeC0M_1Wm2Q6QWADZSpwu-QvqeYNfZM5kEUl0s9g"
 }</code></pre>
 </div>
 </div>
@@ -710,7 +688,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_4">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/join HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/members/join HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -822,7 +800,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_5">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/members HTTP/1.1
 Authorization: Bearer AccessToken</code></pre>
 </div>
 </div>
@@ -892,7 +870,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_6">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member/check-username?username=username123 HTTP/1.1</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/members/check-username?username=username123 HTTP/1.1</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -961,7 +939,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_7">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member/check-nickname?nickname=nickname HTTP/1.1</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/members/check-nickname?nickname=nickname HTTP/1.1</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1030,7 +1008,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_8">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/member/nickname HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/members/nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer AccessToken
 
@@ -1129,7 +1107,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_9">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/member/password HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/members/password HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer AccessToken
 
@@ -1191,7 +1169,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_10">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/email-verification/request HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/members/email-verification/request HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer AccessToken
 
@@ -1246,7 +1224,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_11">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/email-verification/confirm HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/members/email-verification/confirm HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer AccessToken
 
@@ -1308,7 +1286,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_12">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/recover-username HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/members/recover-username HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -1362,7 +1340,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_13">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/recover-password HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/members/recover-password HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -1423,7 +1401,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_14">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/member/recover-password HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/members/recover-password HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -1496,7 +1474,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-08 14:40:39 +0900
+Last updated 2024-01-11 13:22:46 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/daily/daily/integration/oauth/controller/OauthControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/integration/oauth/controller/OauthControllerTest.java
@@ -11,7 +11,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;

--- a/backend/src/test/java/com/daily/daily/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/member/controller/MemberControllerTest.java
@@ -89,7 +89,7 @@ class MemberControllerTest {
 
         given(memberService.join(Mockito.any())).willReturn(expected);
         //when
-        ResultActions joinActions = mockMvc.perform(post("/api/member/join")
+        ResultActions joinActions = mockMvc.perform(post("/api/members/join")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(joinDTO))
                 .with(csrf().asHeader())
@@ -129,7 +129,7 @@ class MemberControllerTest {
         given(memberService.join(Mockito.any())).willThrow(DuplicatedUsernameException.class);
 
         //when
-        ResultActions joinActions = mockMvc.perform(post("/api/member/join")
+        ResultActions joinActions = mockMvc.perform(post("/api/members/join")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(joinDTO))
                 .with(csrf().asHeader())
@@ -152,7 +152,7 @@ class MemberControllerTest {
         given(memberService.findById(Mockito.any())).willReturn(expected);
 
         //when
-        ResultActions actions = mockMvc.perform(get("/api/member")
+        ResultActions actions = mockMvc.perform(get("/api/members")
                 .header(AUTHORIZATION, AccessToken)
                 .with(csrf().asHeader())
         );
@@ -187,7 +187,7 @@ class MemberControllerTest {
         given(memberService.existsByUsername(testUsername)).willReturn(true);
 
         //when
-        ResultActions actions = mockMvc.perform(get("/api/member/check-username")
+        ResultActions actions = mockMvc.perform(get("/api/members/check-username")
                 .param("username", testUsername)
         );
 
@@ -215,7 +215,7 @@ class MemberControllerTest {
         given(memberService.existsByUsername(testUsername)).willReturn(false);
 
         //when
-        ResultActions perform = mockMvc.perform(get("/api/member/check-username")
+        ResultActions perform = mockMvc.perform(get("/api/members/check-username")
                 .param("username", testUsername)
         );
 
@@ -233,7 +233,7 @@ class MemberControllerTest {
         given(memberService.existsByNickname(testNickname)).willReturn(true);
 
         //when
-        ResultActions perform = mockMvc.perform(get("/api/member/check-nickname")
+        ResultActions perform = mockMvc.perform(get("/api/members/check-nickname")
                 .param("nickname", testNickname)
         );
 
@@ -261,7 +261,7 @@ class MemberControllerTest {
         given(memberService.existsByNickname(testNickname)).willReturn(false);
 
         //when
-        ResultActions perform = mockMvc.perform(get("/api/member/check-nickname")
+        ResultActions perform = mockMvc.perform(get("/api/members/check-nickname")
                 .param("nickname", testNickname)
         );
 
@@ -283,7 +283,7 @@ class MemberControllerTest {
 
         given(memberService.updateNickname(Mockito.any(), Mockito.any())).willReturn(expected);
         //when
-        ResultActions perform = mockMvc.perform(patch("/api/member/nickname")
+        ResultActions perform = mockMvc.perform(patch("/api/members/nickname")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(nicknameDTO))
                 .header(AUTHORIZATION, AccessToken)
@@ -320,7 +320,7 @@ class MemberControllerTest {
         PasswordUpdateDTO passwordUpdateDTO = new PasswordUpdateDTO("12345678", "23456789");
 
         //when
-        ResultActions perform = mockMvc.perform(patch("/api/member/password")
+        ResultActions perform = mockMvc.perform(patch("/api/members/password")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(passwordUpdateDTO))
                 .header(AUTHORIZATION, AccessToken)
@@ -348,7 +348,7 @@ class MemberControllerTest {
         EmailDTO emailDTO = new EmailDTO("qkrrjsdn123@naver.com");
 
         //when
-        ResultActions perform = mockMvc.perform(post("/api/member/email-verification/request")
+        ResultActions perform = mockMvc.perform(post("/api/members/email-verification/request")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(emailDTO))
                 .header(AUTHORIZATION, AccessToken)
@@ -375,7 +375,7 @@ class MemberControllerTest {
         EmailVerifyDTO emailVerifyDTO = new EmailVerifyDTO("qkrrjsdn123@naver.com", "315162");
 
         //when
-        ResultActions perform = mockMvc.perform(post("/api/member/email-verification/confirm")
+        ResultActions perform = mockMvc.perform(post("/api/members/email-verification/confirm")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(emailVerifyDTO))
                 .header(AUTHORIZATION, AccessToken)
@@ -403,7 +403,7 @@ class MemberControllerTest {
         EmailDTO emailDTO = new EmailDTO("qkrrjsdn123@naver.com");
 
         //when
-        ResultActions perform = mockMvc.perform(post("/api/member/recover-username")
+        ResultActions perform = mockMvc.perform(post("/api/members/recover-username")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(emailDTO))
                 .with(csrf().asHeader())
@@ -432,7 +432,7 @@ class MemberControllerTest {
         passwordRecoverDTO.setUsername("rjsdn123");
 
         //when
-        ResultActions perform = mockMvc.perform(post("/api/member/recover-password")
+        ResultActions perform = mockMvc.perform(post("/api/members/recover-password")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(passwordRecoverDTO))
                 .with(csrf().asHeader())
@@ -462,7 +462,7 @@ class MemberControllerTest {
         passwordTokenDTO.setPassword("12345678");
 
         //when
-        ResultActions perform = mockMvc.perform(patch("/api/member/recover-password")
+        ResultActions perform = mockMvc.perform(patch("/api/members/recover-password")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(passwordTokenDTO))
                 .with(csrf().asHeader())


### PR DESCRIPTION
## 연관 이슈
close: #132
## 작업 내용

- 엔드포인트 members로 변경하기
  - 관련 Restdocs 수정
-  AuthorizationFilter에서 request의 cookie에 접근해서 토큰을 검증하도록 변경
   - 관련 Restdocs 수정

## 의논할 거리
## Merge 전에 해야할 작업
## 기타
 accessToken 재발급 과정도 cookie로 처리할 수 있도록 수정했습니다.
