### PR TITLE
Moveable 컴포넌트 선택 방식 수정

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -22,7 +22,8 @@
   "plugins": ["react", "import"],
   "rules": {
     "react/react-in-jsx-scope": "off",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "jsx-a11y/no-static-element-interactions": "off"
   },
   "settings": {
     "react": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.6.4",
     "formik": "^2.4.5",
+    "moveable-helper": "^0.4.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/components/da-ily/Moveable/Moveable.jsx
+++ b/frontend/src/components/da-ily/Moveable/Moveable.jsx
@@ -1,28 +1,31 @@
+import { makeMoveable, Rotatable, Draggable, Resizable } from 'react-moveable';
 import PropTypes from 'prop-types';
-import Mvb from 'react-moveable';
+import MoveableHelper from 'moveable-helper';
+import { useState } from 'react';
+
+const MoveableInstance = makeMoveable([Draggable, Rotatable, Resizable]);
 
 const Moveable = (props) => {
-  const { moveableRef, target } = props;
+  const { target } = props;
+  const [helper] = useState(() => {
+    return new MoveableHelper();
+  });
+
   return (
-    <Mvb
-      ref={moveableRef}
+    <MoveableInstance
       target={target}
       draggable={true}
-      onDrag={({ transform }) => {
-        target.style.transform = transform;
-      }}
-      throttleDrag={0}
       resizable={true}
-      throttleResize={0}
-      onResize={({ width, height }) => {
-        target.style.width = `${width}px`;
-        target.style.height = `${height}px`;
-      }}
       rotatable={true}
+      throttleDrag={0}
+      throttleResize={0}
       throttleRotate={0}
-      onRotate={({ transform }) => {
-        target.style.transform = transform;
-      }}
+      onDragStart={helper.onDragStart}
+      onDrag={helper.onDrag}
+      onRotateStart={helper.onRotateStart}
+      onRotate={helper.onRotate}
+      onResizeStart={helper.onResizeStart}
+      onResize={helper.onResize}
     />
   );
 };

--- a/frontend/src/components/decorate/Drawing/Drawing.jsx
+++ b/frontend/src/components/decorate/Drawing/Drawing.jsx
@@ -4,8 +4,7 @@ import useDrawUtils from './useDrawUtils';
 import Button from '../../common/Button/Button';
 import useDrawInstance from './useDrawInstance';
 
-const Drawing = (props) => {
-  const { id } = props;
+const Drawing = () => {
   const canvas = useRef(null);
 
   const { drawInstance } = useDrawInstance(canvas);
@@ -21,16 +20,10 @@ const Drawing = (props) => {
   return (
     <>
       <canvas
-        id={id}
         onMouseDown={(e) => startMoving(e, mouseEventHandlers[mode])}
         onMouseUp={() => stopMoving(mouseEventHandlers[mode])}
         ref={canvas}
       ></canvas>
-      <image id="canvas-draw-image" alt="converted-image" src={imgSrc} />
-      <Button onClick={() => setImgSrc(canvasToImage(id))}>
-        이미지로 변환하기
-      </Button>
-
       <Button onClick={() => saveCanvas()}>저장</Button>
       <Button onClick={() => setMode('drawMode')}>그리기</Button>
 

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -1,39 +1,38 @@
 // Da-ily 회원, 비회원, 다일리 있을때, 없을때를 조건문으로 나눠서 렌더링
 import { useState, useRef } from 'react';
 import Moveable from '../../components/da-ily/Moveable/Moveable';
-import Drawing from '../../components/decorate/Drawing/Drawing';
+
 import * as S from './DailryPage.styled';
 import dailryData from './dailry.json';
 
 const DailryPage = () => {
   const { elements } = dailryData;
   const [target, setTarget] = useState(null);
-  const moveableRef = useRef(null);
+  const moveableRef = useRef([]);
 
-  const handleMouseDown = (e) => {
-    const { nativeEvent } = e;
-    setTarget(nativeEvent.target);
-    if (moveableRef.current) {
-      moveableRef.current.dragStart(nativeEvent);
-    }
+  const handleMouseDown = (e, index) => {
+    setTarget(index);
   };
   return (
     <S.FlexWrapper>
       <S.CanvasWrapper>
-        <Drawing id="first" />
-        {elements.map((element) => {
+        {elements.map((element, index) => {
           const { id, type, position, properties } = element;
           return (
             <div
               key={id}
-              onMouseDown={handleMouseDown}
+              onMouseDown={(e) => handleMouseDown(e, index)}
               style={S.ElementStyle({ position, properties })}
+              ref={(el) => {
+                moveableRef[index] = el;
+              }}
             >
               {type}
+              <div>child element</div>
             </div>
           );
         })}
-        <Moveable target={target} moveableRef={moveableRef} />
+        {target && <Moveable target={moveableRef[target]} />}
       </S.CanvasWrapper>
       <S.ToolWrapper>
         <div>tool1크기</div>


### PR DESCRIPTION
## 연관 이슈
close: #163 
## 작업 내용
- ref 배열에 각 꾸미기 컴포넌트 ref 를 삽입하여, 클릭할시 해당 ref 를 Movable 컴포넌트가 가리키도록 수정
- 관련 이벤트 핸들러 쉽게 등록할 수 있는 moveable-helper 추가
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
