### PR TITLE
꾸미기 컴포넌트 생성

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -22,7 +22,8 @@
   "plugins": ["react", "import"],
   "rules": {
     "react/react-in-jsx-scope": "off",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "jsx-a11y/no-static-element-interactions":"off"
   },
   "settings": {
     "react": {

--- a/frontend/src/components/da-ily/Moveable/Moveable.jsx
+++ b/frontend/src/components/da-ily/Moveable/Moveable.jsx
@@ -31,7 +31,6 @@ const Moveable = (props) => {
 };
 
 Moveable.propTypes = {
-  moveableRef: PropTypes.elementType,
-  target: PropTypes.elementType,
+  target: PropTypes.object,
 };
 export default Moveable;

--- a/frontend/src/hooks/useCreateDecorateComponent.jsx
+++ b/frontend/src/hooks/useCreateDecorateComponent.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+const mockData = {
+  key: new Date().toISOString(),
+  type: null,
+  order: 1,
+  position: {
+    x: null,
+    y: null,
+  },
+  rotation: '90deg',
+  properties: {
+    font: '굴림',
+    fontSize: 12,
+    text: '아 어지럽다.',
+    fontWeight: 'bold',
+    backgroundColor: '#ffcc00',
+    width: 'auto',
+    height: 'auto',
+    color: '#333333',
+  },
+};
+
+const useCreateDecorateComponent = (addToArray) => {
+  const [newDecorateComponent, setNewDecorateComponent] = useState(undefined);
+
+  const createNewDecorateComponent = (type) => {
+    setNewDecorateComponent(() => ({ ...mockData, type }));
+  };
+
+  const setNewDecorateComponentPosition = (e) => {
+    if (!newDecorateComponent) return;
+
+    const { clientX, clientY } = e;
+    setNewDecorateComponent((prev) => ({
+      ...prev,
+      position: { ...prev.position, x: clientX, y: clientY },
+    }));
+  };
+
+  useEffect(() => {
+    if (Number.isSafeInteger(newDecorateComponent?.position?.x)) {
+      addToArray((prev) => prev.concat(newDecorateComponent));
+      setNewDecorateComponent(undefined);
+    }
+  }, [newDecorateComponent?.position?.x]);
+
+  return { createNewDecorateComponent, setNewDecorateComponentPosition };
+};
+
+export default useCreateDecorateComponent;

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -1,14 +1,30 @@
 // Da-ily 회원, 비회원, 다일리 있을때, 없을때를 조건문으로 나눠서 렌더링
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import Moveable from '../../components/da-ily/Moveable/Moveable';
 import Drawing from '../../components/decorate/Drawing/Drawing';
 import * as S from './DailryPage.styled';
 import dailryData from './dailry.json';
+import Button from '../../components/common/Button/Button';
+import useCreateDecorateComponent from '../../hooks/useCreateDecorateComponent';
+
+const DecorateComponents = {
+  drawing: {
+    type: 'drawing',
+    component: <Drawing />,
+  },
+};
 
 const DailryPage = () => {
   const { elements } = dailryData;
   const [target, setTarget] = useState(null);
   const moveableRef = useRef(null);
+  const [decorateComponents, setDecorateComponents] = useState([]);
+  const { setNewDecorateComponentPosition, createNewDecorateComponent } =
+    useCreateDecorateComponent(setDecorateComponents);
+
+  useEffect(() => {
+    // if (elements) setDecorateComponents(elements);
+  }, [elements]);
 
   const handleMouseDown = (e) => {
     const { nativeEvent } = e;
@@ -19,9 +35,9 @@ const DailryPage = () => {
   };
   return (
     <S.FlexWrapper>
-      <S.CanvasWrapper>
+      <S.CanvasWrapper onClick={(e) => setNewDecorateComponentPosition(e)}>
         <Drawing id="first" />
-        {elements.map((element) => {
+        {decorateComponents.map((element) => {
           const { id, type, position, properties } = element;
           return (
             <div
@@ -29,13 +45,16 @@ const DailryPage = () => {
               onMouseDown={handleMouseDown}
               style={S.ElementStyle({ position, properties })}
             >
-              {type}
+              {DecorateComponents[type].component}
             </div>
           );
         })}
-        <Moveable target={target} moveableRef={moveableRef} />
+        {target && <Moveable target={target} moveableRef={moveableRef} />}
       </S.CanvasWrapper>
       <S.ToolWrapper>
+        <Button onClick={() => createNewDecorateComponent('drawing')}>
+          드로잉 컴포넌트 생성
+        </Button>
         <div>tool1크기</div>
         <div>tool2</div>
       </S.ToolWrapper>

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -1,16 +1,21 @@
 // Da-ily 회원, 비회원, 다일리 있을때, 없을때를 조건문으로 나눠서 렌더링
 import { useState, useRef, useEffect } from 'react';
 import Moveable from '../../components/da-ily/Moveable/Moveable';
-
+import Drawing from '../../components/decorate/Drawing/Drawing';
 import * as S from './DailryPage.styled';
 import dailryData from './dailry.json';
 import Button from '../../components/common/Button/Button';
 import useCreateDecorateComponent from '../../hooks/useCreateDecorateComponent';
 
+const TextBox = () => <div>ff</div>;
+
 const DecorateComponents = {
   drawing: {
     type: 'drawing',
     component: <Drawing />,
+  },
+  textbox: {
+    component: <TextBox />,
   },
 };
 
@@ -24,17 +29,16 @@ const DailryPage = () => {
     useCreateDecorateComponent(setDecorateComponents);
 
   useEffect(() => {
-    // if (elements) setDecorateComponents(elements);
+    if (elements) setDecorateComponents(elements);
   }, [elements]);
 
   const handleMouseDown = (e, index) => {
-    setTarget(index);
+    setTarget(index + 1);
   };
   return (
     <S.FlexWrapper>
       <S.CanvasWrapper onClick={(e) => setNewDecorateComponentPosition(e)}>
-        <Drawing id="first" />
-        {decorateComponents.map((element) => {
+        {decorateComponents.map((element, index) => {
           const { id, type, position, properties } = element;
           return (
             <div
@@ -42,7 +46,7 @@ const DailryPage = () => {
               onMouseDown={(e) => handleMouseDown(e, index)}
               style={S.ElementStyle({ position, properties })}
               ref={(el) => {
-                moveableRef[index] = el;
+                moveableRef[index + 1] = el;
               }}
             >
               {DecorateComponents[type].component}
@@ -54,6 +58,9 @@ const DailryPage = () => {
       <S.ToolWrapper>
         <Button onClick={() => createNewDecorateComponent('drawing')}>
           드로잉 컴포넌트 생성
+        </Button>
+        <Button onClick={() => createNewDecorateComponent('textbox')}>
+          텍스트 박스 컴포넌트 생성
         </Button>
         <div>tool1크기</div>
         <div>tool2</div>


### PR DESCRIPTION
## 연관 이슈
close: #154 
## 작업 내용
- useCreateDecorateComponent 커스텀 훅 생성
   - 페이지 를 클릭하면 해당위치에 꾸미기 컴포넌트 생성 
   - 꾸미기 컴포넌트 들이 담겨있는 배열에 삽입/삭제 하는 방식으로 구현.
- `jsx-a11y/no-static-element-interactions` 규칙 제거
   - 서비스 특성상, 일반 엘리멘트에 상호작용가능한 이벤트를 부착해야 하기때문에 제거.
## 의논할 거리
- 페이지 를 클릭하면 컴포넌트가 생성된다는 것을 알려줄 UI/UX 가 필요할 듯 합니다.
- type 에 맞는 컴포넌트를 어떤 방식으로 저장하고 맵핑 할지, 고민해 보면 좋을 듯 합니다.
## Merge 전에 해야할 작업
## 기타
- 새로운 꾸미기 컴포넌트 데이터를 생성하는 로직은 아직 미구현. 툴바가 완성되면 해당 기능 구현 예정.
