### PR TITLE
꾸미기 컴포넌트 생성 위치 계산 로직 수정

### DIFF
--- a/frontend/src/hooks/useCreateDecorateComponent.jsx
+++ b/frontend/src/hooks/useCreateDecorateComponent.jsx
@@ -21,20 +21,29 @@ const mockData = {
   },
 };
 
-const useCreateDecorateComponent = (addToArray) => {
+const useCreateDecorateComponent = (addToArray, parentRef) => {
   const [newDecorateComponent, setNewDecorateComponent] = useState(undefined);
+  const parentX = parentRef?.current?.getBoundingClientRect().left.toFixed();
+  const parentY = parentRef?.current?.getBoundingClientRect().top.toFixed();
 
   const createNewDecorateComponent = (type) => {
     setNewDecorateComponent(() => ({ ...mockData, type }));
   };
 
+  const getNewDecorateComponentPosition = (e) => {
+    const { clientX, clientY } = e;
+    return { x: clientX - parentX, y: clientY - parentY };
+  };
+
   const setNewDecorateComponentPosition = (e) => {
     if (!newDecorateComponent) return;
 
-    const { clientX, clientY } = e;
     setNewDecorateComponent((prev) => ({
       ...prev,
-      position: { ...prev.position, x: clientX, y: clientY },
+      position: {
+        ...prev.position,
+        ...getNewDecorateComponentPosition(e),
+      },
     }));
   };
 

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -24,9 +24,10 @@ const DailryPage = () => {
   const [target, setTarget] = useState(null);
 
   const moveableRef = useRef([]);
+  const parentRef = useRef(null);
   const [decorateComponents, setDecorateComponents] = useState([]);
   const { setNewDecorateComponentPosition, createNewDecorateComponent } =
-    useCreateDecorateComponent(setDecorateComponents);
+    useCreateDecorateComponent(setDecorateComponents, parentRef);
 
   useEffect(() => {
     if (elements) setDecorateComponents(elements);
@@ -37,7 +38,10 @@ const DailryPage = () => {
   };
   return (
     <S.FlexWrapper>
-      <S.CanvasWrapper onClick={(e) => setNewDecorateComponentPosition(e)}>
+      <S.CanvasWrapper
+        ref={parentRef}
+        onClick={(e) => setNewDecorateComponentPosition(e)}
+      >
         {decorateComponents.map((element, index) => {
           const { id, type, position, properties } = element;
           return (

--- a/frontend/src/pages/DailryPage/DailryPage.styled.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.styled.jsx
@@ -12,6 +12,7 @@ export const CanvasWrapper = styled.div`
   height: calc(100dvh - 20px);
   aspect-ratio: 1.35/1;
 
+  overflow: hidden;
   border-radius: 8px;
   background-color: ${BACKGROUND.paper};
 `;


### PR DESCRIPTION
## 연관 이슈
close: #169 
## 작업 내용
- 꾸미기 컴포넌트 생성 위치 를 지정하는 방식 수정
   - 마우스가 클릭되는 절대 위치 값에서, 부모 컨테이너 의 위치를 고려해 상대 위치 값으로 수정 (부모 요소 (컨테이너) Reference 의 `getBoundingClientRect`().`left` 값 - 현재 마우스 가 클릭된 위치)
- 부모 컨테이너 `overflow` : `hidden` 값 추가 
   - 꾸미기 컴포넌트 가 부모 컨테이너 영역을 벗어날 때, 가려지도록 조치
## 의논할 거리
- 꾸미기 컴포넌트 가 부모 컨테이너 영역을 벗어날 때, 어떻게 할지
## Merge 전에 해야할 작업
## 기타
