### PR TITLE
게시글 좋아요 기능 추가하기

### DIFF
--- a/backend/scripts/deploy.sh
+++ b/backend/scripts/deploy.sh
@@ -23,7 +23,7 @@ nohup java -jar \
     1>>$LOG_PATH/app-log.out \
     2>>$LOG_PATH/err-log.out &
 
-sleep 30
+sleep 60
 
 #health check...
 if [ -n "$(netstat -nlpt | grep ${DEPLOY_PORT})" ]; then

--- a/backend/src/docs/asciidoc/api-document.adoc
+++ b/backend/src/docs/asciidoc/api-document.adoc
@@ -265,6 +265,27 @@ include::{snippets}/다일리 삭제/response-fields.adoc[]
 
 == 게시글
 
+== 게시글 좋아요
+
+=== 좋아요 증가
+
+==== 요청
+
+include::{snippets}/좋아요 증가/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/좋아요 취소/http-response.adoc[]
+
+=== 좋아요 취소
+
+==== 요청
+
+include::{snippets}/좋아요 증가/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/좋아요 취소/http-response.adoc[]
 
 == 댓글
 

--- a/backend/src/main/java/com/daily/daily/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/daily/daily/auth/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
         http.formLogin(AbstractHttpConfigurer::disable);
         http.logout(AbstractHttpConfigurer::disable);
         http.authorizeHttpRequests(registry -> registry
+                .requestMatchers("/api/posts/*/likes").authenticated()
                 .anyRequest().permitAll()
         );
         http.exceptionHandling(configurer -> configurer

--- a/backend/src/main/java/com/daily/daily/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/daily/daily/auth/config/SecurityConfig.java
@@ -41,7 +41,6 @@ public class SecurityConfig {
         http.formLogin(AbstractHttpConfigurer::disable);
         http.logout(AbstractHttpConfigurer::disable);
         http.authorizeHttpRequests(registry -> registry
-//                .requestMatchers("/api/posts/**/likes").authenticated()
                 .anyRequest().permitAll()
         );
         http.exceptionHandling(configurer -> configurer

--- a/backend/src/main/java/com/daily/daily/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/daily/daily/auth/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
         http.formLogin(AbstractHttpConfigurer::disable);
         http.logout(AbstractHttpConfigurer::disable);
         http.authorizeHttpRequests(registry -> registry
+//                .requestMatchers("/api/posts/**/likes").authenticated()
                 .anyRequest().permitAll()
         );
         http.exceptionHandling(configurer -> configurer

--- a/backend/src/main/java/com/daily/daily/post/PostExceptionHandler.java
+++ b/backend/src/main/java/com/daily/daily/post/PostExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.daily.daily.post;
 
 import com.daily.daily.common.dto.ExceptionResponseDTO;
+import com.daily.daily.post.exception.AlreadyLikeException;
+import com.daily.daily.post.exception.LikeDecreaseNotAllowedException;
 import com.daily.daily.post.exception.PostNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -16,5 +18,13 @@ public class PostExceptionHandler {
     })
     public ResponseEntity<ExceptionResponseDTO> handleNotFoundException(RuntimeException e) {
         return new ResponseEntity<>(new ExceptionResponseDTO(e.getMessage(), 404), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler({
+            AlreadyLikeException.class,
+            LikeDecreaseNotAllowedException.class
+    })
+    public ResponseEntity<ExceptionResponseDTO> handleLikeException(RuntimeException e) {
+        return new ResponseEntity<>(new ExceptionResponseDTO(e.getMessage(), 409), HttpStatus.CONFLICT);
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/controller/PostController.java
+++ b/backend/src/main/java/com/daily/daily/post/controller/PostController.java
@@ -1,8 +1,9 @@
 package com.daily.daily.post.controller;
 
 import com.daily.daily.common.dto.SuccessResponseDTO;
+import com.daily.daily.post.dto.PostReadResponseDTO;
 import com.daily.daily.post.dto.PostRequestDTO;
-import com.daily.daily.post.dto.PostResponseDTO;
+import com.daily.daily.post.dto.PostWriteResponseDTO;
 import com.daily.daily.post.service.PostService;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
@@ -13,7 +14,6 @@ import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,8 +21,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/posts")
@@ -37,7 +35,7 @@ public class PostController {
     @PostMapping
     @Secured(value = "ROLE_MEMBER")
     @ResponseStatus(HttpStatus.CREATED)
-    public PostResponseDTO createPost(
+    public PostWriteResponseDTO createPost(
             @AuthenticationPrincipal Long id,
             @RequestPart @Valid PostRequestDTO request,
             @RequestPart @NotNull MultipartFile pageImage
@@ -47,7 +45,7 @@ public class PostController {
 
     @PostMapping("/{postId}/edit")
     @Secured(value = "ROLE_MEMBER")
-    public PostResponseDTO updatePost(
+    public PostWriteResponseDTO updatePost(
             @PathVariable Long postId,
             @RequestPart @Valid PostRequestDTO request,
             @RequestPart @Nullable MultipartFile pageImage
@@ -56,7 +54,7 @@ public class PostController {
     }
 
     @GetMapping("/{postId}")
-    public PostResponseDTO readSinglePost(@PathVariable Long postId) {
+    public PostReadResponseDTO readSinglePost(@PathVariable Long postId) {
         return postService.find(postId);
     }
 

--- a/backend/src/main/java/com/daily/daily/post/controller/PostLikeController.java
+++ b/backend/src/main/java/com/daily/daily/post/controller/PostLikeController.java
@@ -1,0 +1,31 @@
+package com.daily.daily.post.controller;
+
+import com.daily.daily.common.dto.SuccessResponseDTO;
+import com.daily.daily.post.service.PostLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts/{postId}/likes")
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    @PostMapping
+    public SuccessResponseDTO increaseLikeCount(@AuthenticationPrincipal Long memberId, @PathVariable Long postId) {
+        postLikeService.increaseLikeCount(memberId, postId);
+        return new SuccessResponseDTO();
+    }
+
+    @DeleteMapping
+    public SuccessResponseDTO decreaseLikeCount(@AuthenticationPrincipal Long memberId, @PathVariable Long postId) {
+        postLikeService.decreaseLikeCount(memberId, postId);
+        return new SuccessResponseDTO();
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/domain/PostLike.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/PostLike.java
@@ -1,0 +1,32 @@
+package com.daily.daily.post.domain;
+
+import com.daily.daily.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor @Builder @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/backend/src/main/java/com/daily/daily/post/dto/PostReadResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostReadResponseDTO.java
@@ -5,35 +5,35 @@ import com.daily.daily.post.domain.Post;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-
 @Getter
 @Setter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-@EqualsAndHashCode
-public class PostResponseDTO {
+public class PostReadResponseDTO {
     private Long postId;
     private String content;
     private String pageImage;
     private Long writerId;
     private String writerNickname;
+    private Long likeCount;
     private LocalDateTime createdTime;
 
-    public static PostResponseDTO from(Post post) {
+    public static PostReadResponseDTO from(Post post, Long likeCount) {
         Member postWriter = post.getPostWriter();
 
-        return PostResponseDTO.builder()
+        return PostReadResponseDTO.builder()
                 .postId(post.getId())
                 .content(post.getContent())
                 .pageImage(post.getPageImage())
                 .writerId(postWriter.getId())
                 .writerNickname(postWriter.getNickname())
                 .createdTime(post.getCreatedTime())
+                .likeCount(likeCount)
                 .build();
     }
 }
+

--- a/backend/src/main/java/com/daily/daily/post/dto/PostWriteResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostWriteResponseDTO.java
@@ -1,0 +1,39 @@
+package com.daily.daily.post.dto;
+
+import com.daily.daily.member.domain.Member;
+import com.daily.daily.post.domain.Post;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@EqualsAndHashCode
+public class PostWriteResponseDTO { // 수정, 삭제 전용 응답 DTO
+    private Long postId;
+    private String content;
+    private String pageImage;
+    private Long writerId;
+    private String writerNickname;
+    private LocalDateTime createdTime;
+
+    public static PostWriteResponseDTO from(Post post) {
+        Member postWriter = post.getPostWriter();
+
+        return PostWriteResponseDTO.builder()
+                .postId(post.getId())
+                .content(post.getContent())
+                .pageImage(post.getPageImage())
+                .writerId(postWriter.getId())
+                .writerNickname(postWriter.getNickname())
+                .createdTime(post.getCreatedTime())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/exception/AlreadyLikeException.java
+++ b/backend/src/main/java/com/daily/daily/post/exception/AlreadyLikeException.java
@@ -1,0 +1,7 @@
+package com.daily.daily.post.exception;
+
+public class AlreadyLikeException extends RuntimeException{
+    public AlreadyLikeException() {
+        super("이미 좋아요를 누른 게시글입니다.");
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/exception/LikeDecreaseNotAllowedException.java
+++ b/backend/src/main/java/com/daily/daily/post/exception/LikeDecreaseNotAllowedException.java
@@ -1,0 +1,7 @@
+package com.daily.daily.post.exception;
+
+public class LikeDecreaseNotAllowedException extends RuntimeException{
+    public LikeDecreaseNotAllowedException() {
+        super("좋아요를 취소할 수 없습니다. 좋아요를 누르지 않은 게시글 입니다.");
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/repository/PostLikeRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostLikeRepository.java
@@ -1,0 +1,21 @@
+package com.daily.daily.post.repository;
+
+import com.daily.daily.post.domain.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    //TODO: 현재는 select count로 존재 여부를 처리하지만 성능상 좋지 않다.
+    //      해당 조건에 맞는 row가 존재해도 그 자리에서 return 을 하는 것이 아니라 계속 순회하며 count를 세기 때문.
+    //      추후에 Querydsl 이용해서 최적화가 필요함
+    
+    @Query("select count(pl.id) > 0 from PostLike pl where pl.post.id = :postId and pl.member.id = :memberId")
+    boolean existsBy(Long memberId, Long postId);
+
+    @Query("select pl from PostLike pl where pl.post.id = :postId and pl.member.id = :memberId")
+    Optional<PostLike> findBy(Long memberId, Long postId);
+}
+

--- a/backend/src/main/java/com/daily/daily/post/repository/PostLikeRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostLikeRepository.java
@@ -9,13 +9,6 @@ import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
-    //TODO: 현재는 select count로 존재 여부를 처리하지만 성능상 좋지 않다.
-    //      해당 조건에 맞는 row가 존재해도 그 자리에서 return 을 하는 것이 아니라 계속 순회하며 count를 세기 때문.
-    //      추후에 Querydsl 이용해서 최적화가 필요함
-    
-    @Query("select count(pl.id) > 0 from PostLike pl where pl.post.id = :postId and pl.member.id = :memberId")
-    boolean existsBy(Long memberId, Long postId);
-
     @Query("select pl from PostLike pl where pl.post.id = :postId and pl.member.id = :memberId")
     Optional<PostLike> findBy(Long memberId, Long postId);
 

--- a/backend/src/main/java/com/daily/daily/post/repository/PostLikeRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostLikeRepository.java
@@ -1,5 +1,6 @@
 package com.daily.daily.post.repository;
 
+import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.domain.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,5 +18,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     @Query("select pl from PostLike pl where pl.post.id = :postId and pl.member.id = :memberId")
     Optional<PostLike> findBy(Long memberId, Long postId);
+
+    Long countByPost(Post post);
 }
 

--- a/backend/src/main/java/com/daily/daily/post/service/PostLikeService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostLikeService.java
@@ -21,6 +21,7 @@ public class PostLikeService {
     private final PostLikeRepository likeRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+
     public void increaseLikeCount(Long memberId, Long postId) {
         if (likeRepository.existsBy(memberId, postId)) {
             throw new AlreadyLikeException();

--- a/backend/src/main/java/com/daily/daily/post/service/PostLikeService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostLikeService.java
@@ -18,11 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class PostLikeService {
-    private final PostLikeRepository postLikeRepository;
+    private final PostLikeRepository likeRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     public void increaseLikeCount(Long memberId, Long postId) {
-        if (postLikeRepository.existsBy(memberId, postId)) {
+        if (likeRepository.existsBy(memberId, postId)) {
             throw new AlreadyLikeException();
         }
 
@@ -34,13 +34,13 @@ public class PostLikeService {
                 .post(findPost)
                 .build();
 
-        postLikeRepository.save(like);
+        likeRepository.save(like);
     }
 
     public void decreaseLikeCount(Long memberId, Long postId) {
-        PostLike like = postLikeRepository.findBy(memberId, postId)
+        PostLike like = likeRepository.findBy(memberId, postId)
                 .orElseThrow(LikeDecreaseNotAllowedException::new);
 
-        postLikeRepository.delete(like);
+        likeRepository.delete(like);
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/service/PostLikeService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostLikeService.java
@@ -1,0 +1,46 @@
+package com.daily.daily.post.service;
+
+import com.daily.daily.member.domain.Member;
+import com.daily.daily.member.exception.MemberNotFoundException;
+import com.daily.daily.member.repository.MemberRepository;
+import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.domain.PostLike;
+import com.daily.daily.post.exception.AlreadyLikeException;
+import com.daily.daily.post.exception.LikeDecreaseNotAllowedException;
+import com.daily.daily.post.exception.PostNotFoundException;
+import com.daily.daily.post.repository.PostLikeRepository;
+import com.daily.daily.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostLikeService {
+    private final PostLikeRepository postLikeRepository;
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    public void increaseLikeCount(Long memberId, Long postId) {
+        if (postLikeRepository.existsBy(memberId, postId)) {
+            throw new AlreadyLikeException();
+        }
+
+        Member findMember = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        Post findPost = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+
+        PostLike like = PostLike.builder()
+                .member(findMember)
+                .post(findPost)
+                .build();
+
+        postLikeRepository.save(like);
+    }
+
+    public void decreaseLikeCount(Long memberId, Long postId) {
+        PostLike like = postLikeRepository.findBy(memberId, postId)
+                .orElseThrow(LikeDecreaseNotAllowedException::new);
+
+        postLikeRepository.delete(like);
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/service/PostLikeService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostLikeService.java
@@ -23,7 +23,7 @@ public class PostLikeService {
     private final PostRepository postRepository;
 
     public void increaseLikeCount(Long memberId, Long postId) {
-        if (likeRepository.existsBy(memberId, postId)) {
+        if (likeRepository.findBy(memberId, postId).isPresent()) {
             throw new AlreadyLikeException();
         }
 

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -479,6 +479,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </ul>
 </li>
 <li><a href="#_게시글">게시글</a></li>
+<li><a href="#_게시글_좋아요">게시글 좋아요</a>
+<ul class="sectlevel2">
+<li><a href="#_좋아요_증가">좋아요 증가</a></li>
+<li><a href="#_좋아요_취소">좋아요 취소</a></li>
+</ul>
+</li>
 <li><a href="#_댓글">댓글</a>
 <ul class="sectlevel2">
 <li><a href="#_댓글_작성">댓글 작성</a></li>
@@ -526,8 +532,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxNiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA1OTE4NDIxfQ.MTMxYeJPGFASply47R1OcvYLDjMqBNNul-pH0XvM7FJgr4CRCgh5goCgLfXE85gHpq9FtcX-s9Ti9dfQWxupwg
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTYsImlhdCI6MTcwNTkxNDgyMSwiZXhwIjoxNzA3MTI0NDIxfQ.O8zYSt756AOgbEcDNCKGpHB6G1ddQrrYMAG9bUc9qohYI8JyOp4L_GEks-E5qb6EaIgoCLGF7aPnTC8PDJgoWw
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxNiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA2MTAzNTUyfQ.2HoC67pO03bGa6xquyAA0QcJB2wFPnSfwGdcT0aRC5_EUgltofdBOD6Of0hH4uP94lcz_3vX-vX306cSAMyhfA
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTYsImlhdCI6MTcwNjA5OTk1MiwiZXhwIjoxNzA3MzA5NTUyfQ.sXU282SB9C-SuIs8qU1X_GsHTw_vpai6cfsxmK3763HK_GFzYvFJfmSp8mg01IqDhmfqg0ysgivBCthKFEzYpw
 
 {
   "username" : "testtest",
@@ -571,8 +577,8 @@ Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTYsImlhdCI6MTcwNTkxND
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxNiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA1OTE4NDIxfQ.MTMxYeJPGFASply47R1OcvYLDjMqBNNul-pH0XvM7FJgr4CRCgh5goCgLfXE85gHpq9FtcX-s9Ti9dfQWxupwg; Path=/; Secure; HttpOnly; SameSite=None
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTYsImlhdCI6MTcwNTkxNDgyMSwiZXhwIjoxNzA3MTI0NDIxfQ.O8zYSt756AOgbEcDNCKGpHB6G1ddQrrYMAG9bUc9qohYI8JyOp4L_GEks-E5qb6EaIgoCLGF7aPnTC8PDJgoWw; Path=/; Secure; HttpOnly; SameSite=None
+Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxNiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA2MTAzNTUyfQ.2HoC67pO03bGa6xquyAA0QcJB2wFPnSfwGdcT0aRC5_EUgltofdBOD6Of0hH4uP94lcz_3vX-vX306cSAMyhfA; Path=/; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTYsImlhdCI6MTcwNjA5OTk1MiwiZXhwIjoxNzA3MzA5NTUyfQ.sXU282SB9C-SuIs8qU1X_GsHTw_vpai6cfsxmK3763HK_GFzYvFJfmSp8mg01IqDhmfqg0ysgivBCthKFEzYpw; Path=/; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -591,8 +597,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/logout HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo2LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDU5MTg0MjB9.zVSACIKJiZURlUzB94Isgo3Zi2D3BNAFqTWp1t_PfQnBqN2HFNOQj61R_CrFIwMSJNZl9hTl0yXPJbFuSejqhQ
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NiwiaWF0IjoxNzA1OTE0ODIwLCJleHAiOjE3MDcxMjQ0MjB9._PfEG7ykeO34w13smZBLOyMrQpqRzrHP3jMVxFsEedq1ywKP1tfSw5nRsYPG6x9Lw5ilCRBZHSEcbSuYphh5oQ</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo2LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDYxMDM1NTF9.LjBQYxEvhKxlUJ2UlnQIUo3Mcx39ULm6vDpV8EOQWq7GeCq0DcDdhffRsBE2nCfDBiTRa0RZpzHRakrTIAVVAA
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NiwiaWF0IjoxNzA2MDk5OTUxLCJleHAiOjE3MDczMDk1NTF9.nRXnKZ_imr0bbeCQRMPjCgxK79xmI2jRCuV12HOE5xpOHYNXTvCSJXLhZ_Rv3dIIRKDH9-U90Bu7UxloxyhC_g</code></pre>
 </div>
 </div>
 </div>
@@ -621,8 +627,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/token HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo4LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDU5MTg0MjB9.LwVtVjJI2ZtSoGRdVRJIs2oI7c3iwZgB8bF9K48lQ0mi1dF_9BCN63_ovhzruDQqSV8_NW6xFqbpLYeNDmcHhg
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6OCwiaWF0IjoxNzA1OTE0ODIwLCJleHAiOjE3MDcxMjQ0MjB9.46iZigf9OwQ7Tq7by2ibcNoq6dL1nTJblTAfOWRB26h0-ZDq_exz29x1ozhwBpAwWpgIghuBC8fPOLk0n8rTfQ</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo4LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDYxMDM1NTJ9.2BA-j8cgZQCn84SRuaVCNomBnreREwXUrEtRRKRplJZGh9jge0eviXGD7UYVpJB_QEchtA_PJeBoRvxHc3s2JA
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6OCwiaWF0IjoxNzA2MDk5OTUyLCJleHAiOjE3MDczMDk1NTJ9.j9mwrkzaLasdTGOiT-iKhr9xgk6LW7P8H90c7la5DVt44V2NsHoaossr2eRrs4Zz2Mz-RNWx0p5E1wMS96F40A</code></pre>
 </div>
 </div>
 </div>
@@ -1840,12 +1846,69 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect1">
+<h2 id="_게시글_좋아요">게시글 좋아요</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_좋아요_증가">좋아요 증가</h3>
+<div class="sect3">
+<h4 id="_요청_20">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/posts/31/likes HTTP/1.1
+Content-Type: */*;charset=UTF-8</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_20">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "statusCode" : 200,
+  "successful" : true
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_좋아요_취소">좋아요 취소</h3>
+<div class="sect3">
+<h4 id="_요청_21">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/posts/31/likes HTTP/1.1
+Content-Type: */*;charset=UTF-8</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_21">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "statusCode" : 200,
+  "successful" : true
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
 <h2 id="_댓글">댓글</h2>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_댓글_작성">댓글 작성</h3>
 <div class="sect3">
-<h4 id="_요청_20">요청</h4>
+<h4 id="_요청_22">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/posts/31/comments HTTP/1.1
@@ -1901,7 +1964,7 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_20">응답</h4>
+<h4 id="_응답_22">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
@@ -1976,7 +2039,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_댓글_수정">댓글 수정</h3>
 <div class="sect3">
-<h4 id="_요청_21">요청</h4>
+<h4 id="_요청_23">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/posts/comments/16 HTTP/1.1
@@ -2032,7 +2095,7 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_21">응답</h4>
+<h4 id="_응답_23">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2107,7 +2170,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_댓글_조회">댓글 조회</h3>
 <div class="sect3">
-<h4 id="_요청_22">요청</h4>
+<h4 id="_요청_24">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/posts/31/comments?page=0&amp;size=3 HTTP/1.1</code></pre>
@@ -2160,7 +2223,7 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_22">응답</h4>
+<h4 id="_응답_24">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2253,7 +2316,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_댓글_삭제">댓글 삭제</h3>
 <div class="sect3">
-<h4 id="_요청_23">요청</h4>
+<h4 id="_요청_25">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/posts/comments/16 HTTP/1.1</code></pre>
@@ -2280,7 +2343,7 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_23">응답</h4>
+<h4 id="_응답_25">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2300,7 +2363,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-22 17:54:45 +0900
+Last updated 2024-01-24 21:36:02 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/daily/daily/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/PostControllerTest.java
@@ -2,7 +2,7 @@ package com.daily.daily.post.controller;
 
 import com.daily.daily.auth.jwt.JwtAuthorizationFilter;
 import com.daily.daily.auth.jwt.JwtUtil;
-import com.daily.daily.post.dto.PostResponseDTO;
+import com.daily.daily.post.dto.PostWriteResponseDTO;
 import com.daily.daily.post.service.PostService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
@@ -22,8 +22,9 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
 
+import static com.daily.daily.post.fixture.PostFixture.게시글_단건_조회_DTO;
 import static com.daily.daily.post.fixture.PostFixture.게시글_요청_DTO_JSON_파일;
-import static com.daily.daily.post.fixture.PostFixture.게시글_응답_DTO;
+import static com.daily.daily.post.fixture.PostFixture.게시글_작성_응답_DTO;
 import static com.daily.daily.post.fixture.PostFixture.다일리_페이지_이미지_파일;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -58,7 +59,7 @@ class PostControllerTest {
     @WithMockUser
     void createPost() throws Exception {
         //given
-        given(postService.create(any(), any(), any())).willReturn(게시글_응답_DTO());
+        given(postService.create(any(), any(), any())).willReturn(게시글_작성_응답_DTO());
 
         //when
         ResultActions perform = mockMvc.perform(multipart("/api/posts")
@@ -74,8 +75,8 @@ class PostControllerTest {
                 .getResponse()
                 .getContentAsString(StandardCharsets.UTF_8);
 
-        PostResponseDTO 실제_테스트_응답_결과 = objectMapper.readValue(content, PostResponseDTO.class);
-        assertThat(게시글_응답_DTO()).isEqualTo(실제_테스트_응답_결과);
+        PostWriteResponseDTO 실제_테스트_응답_결과 = objectMapper.readValue(content, PostWriteResponseDTO.class);
+        assertThat(게시글_작성_응답_DTO()).isEqualTo(실제_테스트_응답_결과);
     }
 
 
@@ -87,7 +88,7 @@ class PostControllerTest {
         @DisplayName("게시글 수정 요청에 이미지 파일과, Json정보를 전부 보냈을 경우 응답값을 검사한다.")
         void imageAndJson() throws Exception {
             //given
-            given(postService.update(any(), any(), any())).willReturn(게시글_응답_DTO());
+            given(postService.update(any(), any(), any())).willReturn(게시글_작성_응답_DTO());
 
             //when
             ResultActions perform = mockMvc.perform(multipart("/api/posts/31/edit")
@@ -103,8 +104,8 @@ class PostControllerTest {
                     .getResponse()
                     .getContentAsString(StandardCharsets.UTF_8);
 
-            PostResponseDTO 실제_테스트_응답_결과 = objectMapper.readValue(content, PostResponseDTO.class);
-            assertThat(게시글_응답_DTO()).isEqualTo(실제_테스트_응답_결과);
+            PostWriteResponseDTO 실제_테스트_응답_결과 = objectMapper.readValue(content, PostWriteResponseDTO.class);
+            assertThat(게시글_작성_응답_DTO()).isEqualTo(실제_테스트_응답_결과);
         }
 
         @Test
@@ -162,7 +163,7 @@ class PostControllerTest {
         @WithMockUser
         @DisplayName("게시글 단건 조회가 성공했을 때 응답결과를 검사한다.")
         void test1() throws Exception {
-            given(postService.find(31L)).willReturn(게시글_응답_DTO());
+            given(postService.find(31L)).willReturn(게시글_단건_조회_DTO());
 
             ResultActions perform = mockMvc.perform(get("/api/posts/31")
                     .with(csrf().asHeader())
@@ -173,8 +174,8 @@ class PostControllerTest {
                     .getResponse()
                     .getContentAsString(StandardCharsets.UTF_8);
 
-            PostResponseDTO 테스트_조회_결과 = objectMapper.readValue(content, PostResponseDTO.class);
-            Assertions.assertThat(게시글_응답_DTO()).isEqualTo(테스트_조회_결과);
+            PostWriteResponseDTO 테스트_조회_결과 = objectMapper.readValue(content, PostWriteResponseDTO.class);
+            Assertions.assertThat(게시글_작성_응답_DTO()).isEqualTo(테스트_조회_결과);
         }
     }
 }

--- a/backend/src/test/java/com/daily/daily/post/controller/PostLikeControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/PostLikeControllerTest.java
@@ -1,0 +1,85 @@
+package com.daily.daily.post.controller;
+
+import com.daily.daily.auth.jwt.JwtAuthorizationFilter;
+import com.daily.daily.auth.jwt.JwtUtil;
+import com.daily.daily.post.service.PostLikeService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.daily.daily.post.fixture.PostFixture.POST_ID;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = PostLikeController.class, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
+})
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+class PostLikeControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    PostLikeService postLikeService;
+
+    @Nested
+    @DisplayName("increaseLikeCount() - 좋아요 증가 메서드 테스트")
+    class increaseLikeCount {
+
+        @Test
+        @DisplayName("성공적으로 좋아요를 증가시켰을 경우 응답 결과를 확인한다.")
+        @WithMockUser
+        void test1() throws Exception {
+            //when
+            ResultActions perform = mockMvc.perform(post("/api/posts/{postId}/likes", POST_ID)
+                    .with(csrf().asHeader())
+            );
+
+            //then
+            perform.andExpect(status().isOk())
+                    .andDo(print())
+                    .andExpect(jsonPath("$.successful").value(true))
+                    .andExpect(jsonPath("$.statusCode").value(200));
+        }
+    }
+    
+    @Nested
+    @DisplayName("decreasedLikeCount() - 좋아요 감소 메서드 테스트")
+    class decreaseLikeCount {
+        @Test
+        @DisplayName("성공적으로 좋아요를 감소시켰을 경우 응답 결과를 확인한다.")
+        @WithMockUser
+        void test1() throws Exception {
+            //when
+            ResultActions perform = mockMvc.perform(delete("/api/posts/{postId}/likes", POST_ID)
+                    .with(csrf().asHeader())
+            );
+
+            //then
+            perform.andExpect(status().isOk())
+                    .andDo(print())
+                    .andExpect(jsonPath("$.successful").value(true))
+                    .andExpect(jsonPath("$.statusCode").value(200));
+        }
+    }
+}

--- a/backend/src/test/java/com/daily/daily/post/controller/PostLikeControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/PostLikeControllerTest.java
@@ -14,13 +14,17 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static com.daily.daily.post.fixture.PostFixture.POST_ID;
+import static com.daily.daily.testutil.document.RestDocsUtil.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -53,6 +57,7 @@ class PostLikeControllerTest {
             //when
             ResultActions perform = mockMvc.perform(post("/api/posts/{postId}/likes", POST_ID)
                     .with(csrf().asHeader())
+                    .contentType(MediaType.ALL)
             );
 
             //then
@@ -60,19 +65,27 @@ class PostLikeControllerTest {
                     .andDo(print())
                     .andExpect(jsonPath("$.successful").value(true))
                     .andExpect(jsonPath("$.statusCode").value(200));
+
+            //restdocs
+            perform.andDo(document("좋아요 증가",
+                    pathParameters(
+                            parameterWithName("postId").description("좋아요할 게시글 id")
+                    )
+            ));
         }
     }
     
     @Nested
-    @DisplayName("decreasedLikeCount() - 좋아요 감소 메서드 테스트")
+    @DisplayName("decreasedLikeCount() - 좋아요 취소 메서드 테스트")
     class decreaseLikeCount {
         @Test
-        @DisplayName("성공적으로 좋아요를 감소시켰을 경우 응답 결과를 확인한다.")
+        @DisplayName("성공적으로 좋아요를 취소시켰을 경우 응답 결과를 확인한다.")
         @WithMockUser
         void test1() throws Exception {
             //when
             ResultActions perform = mockMvc.perform(delete("/api/posts/{postId}/likes", POST_ID)
                     .with(csrf().asHeader())
+                    .contentType(MediaType.ALL)
             );
 
             //then
@@ -80,6 +93,13 @@ class PostLikeControllerTest {
                     .andDo(print())
                     .andExpect(jsonPath("$.successful").value(true))
                     .andExpect(jsonPath("$.statusCode").value(200));
+
+            //restdocs
+            perform.andDo(document("좋아요 취소",
+                    pathParameters(
+                            parameterWithName("postId").description("좋아요를 취소할 게시글 id")
+                    )
+            ));
         }
     }
 }

--- a/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
+++ b/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
@@ -2,8 +2,9 @@ package com.daily.daily.post.fixture;
 
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.dto.PostReadResponseDTO;
 import com.daily.daily.post.dto.PostRequestDTO;
-import com.daily.daily.post.dto.PostResponseDTO;
+import com.daily.daily.post.dto.PostWriteResponseDTO;
 import org.springframework.mock.web.MockMultipartFile;
 import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,16 +28,30 @@ public class PostFixture {
         return new PostRequestDTO(POST_CONTENT);
     }
 
-    public static PostResponseDTO 게시글_응답_DTO() {
+    public static PostWriteResponseDTO 게시글_작성_응답_DTO() {
         Member member = 일반회원1();
 
-        return PostResponseDTO.builder()
+        return PostWriteResponseDTO.builder()
                 .postId(POST_ID)
                 .content(POST_CONTENT)
                 .pageImage(PAGE_IMAGE_URL)
                 .writerId(member.getId())
                 .writerNickname(member.getNickname())
                 .createdTime(POST_CREATED_TIME)
+                .build();
+    }
+
+    public static PostReadResponseDTO 게시글_단건_조회_DTO() {
+        PostWriteResponseDTO 게시글_작성_응답_DTO = 게시글_작성_응답_DTO();
+
+        return PostReadResponseDTO.builder()
+                .postId(게시글_작성_응답_DTO.getPostId())
+                .content(게시글_작성_응답_DTO.getContent())
+                .pageImage(게시글_작성_응답_DTO.getPageImage())
+                .writerId(게시글_작성_응답_DTO().getWriterId())
+                .writerNickname(게시글_작성_응답_DTO().getWriterNickname())
+                .createdTime(게시글_작성_응답_DTO().getCreatedTime())
+                .likeCount(10L)
                 .build();
     }
 

--- a/backend/src/test/java/com/daily/daily/post/repository/PostLikeRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/post/repository/PostLikeRepositoryTest.java
@@ -1,0 +1,63 @@
+package com.daily.daily.post.repository;
+
+import com.daily.daily.member.domain.Member;
+import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.domain.PostLike;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+class PostLikeRepositoryTest {
+
+    @Autowired
+    PostLikeRepository likeRepository;
+
+    @Autowired
+    TestEntityManager testEntityManager;
+    private final Member 테스트_멤버 = Member
+            .builder()
+            .build();
+    private final Post 테스트_게시글 = Post
+            .builder()
+            .postWriter(테스트_멤버)
+            .build();
+
+    @Nested
+    @DisplayName("findBy() 좋아요 이력 존재 여부 메서드 테스트")
+    class findBy {
+        @Test
+        @DisplayName("좋아요 이력이 존재하는 경우, findBy() 메서드는 PostLike 객체를 올바르게 반환해야 한다.")
+        void test1() {
+            //given
+            PostLike like = PostLike.builder()
+                    .post(테스트_게시글)
+                    .member(테스트_멤버)
+                    .build();
+
+            testEntityManager.persist(테스트_게시글);
+            testEntityManager.persist(테스트_멤버);
+            likeRepository.save(like);
+
+            //when
+            PostLike findLike = likeRepository.findBy(테스트_멤버.getId(), 테스트_게시글.getId())
+                    .orElseThrow(IllegalArgumentException::new);
+
+            //then
+            Assertions.assertThat(findLike).isEqualTo(like);
+        }
+
+        @Test
+        @DisplayName("좋아요 이력이 존재하지 않는경우, findBy()메서드는 빈 Optional을 반환해야 한다.")
+        void test2() {
+            //when
+            boolean isEmpty = likeRepository.findBy(3L, 5L).isEmpty();
+            //then
+            Assertions.assertThat(isEmpty).isTrue();
+        }
+    }
+}

--- a/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceTest.java
@@ -1,0 +1,102 @@
+package com.daily.daily.post.service;
+
+import com.daily.daily.member.domain.Member;
+import com.daily.daily.member.repository.MemberRepository;
+import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.domain.PostLike;
+import com.daily.daily.post.exception.AlreadyLikeException;
+import com.daily.daily.post.exception.LikeDecreaseNotAllowedException;
+import com.daily.daily.post.repository.PostLikeRepository;
+import com.daily.daily.post.repository.PostRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.daily.daily.member.fixture.MemberFixture.일반회원2;
+import static com.daily.daily.post.fixture.PostFixture.일반회원1이_작성한_게시글;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PostLikeServiceTest {
+
+    @Mock
+    PostLikeRepository likeRepository;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    PostRepository postRepository;
+    @InjectMocks
+    PostLikeService postLikeService;
+
+    @Nested
+    @DisplayName("increaseLikeCount() - 좋아요 증가 메서드 테스트")
+    class increaseLikeCount{
+        @Test
+        @DisplayName("memberId와 postId로 좋아요 이력을 조회 했을 때 이미 존재하면 AlreadyLikeException 예외를 발생한다")
+        void test1() {
+            //given
+            PostLike like = PostLike
+                    .builder()
+                    .build();
+
+            when(likeRepository.findBy(any(Long.class), any(Long.class))).thenReturn(Optional.of(like));
+
+            //when
+            assertThatThrownBy(() -> postLikeService.increaseLikeCount(any(Long.class), any(Long.class)))
+                    .isInstanceOf(AlreadyLikeException.class);
+        }
+
+        @Test
+        @DisplayName("좋아요 이력을 저장할 때, 파라미터 정보에 맞게 올바르게 저장하는지 검사한다.")
+        void test2() {
+            //given : 일반회원 2가 일반회원 1이작성한 게시글에 좋아요를 누른다.
+            Member 일반회원2 = 일반회원2();
+            Post 일반회원1이_작성한_게시글 = 일반회원1이_작성한_게시글();
+
+            when(memberRepository.findById(일반회원2.getId())).thenReturn(Optional.of(일반회원2()));
+            when(postRepository.findById(일반회원1이_작성한_게시글.getId())).thenReturn(Optional.of(일반회원1이_작성한_게시글));
+
+            ArgumentCaptor<PostLike> postLikeCaptor = ArgumentCaptor.forClass(PostLike.class);
+
+            //when
+            postLikeService.increaseLikeCount(일반회원2.getId(), 일반회원1이_작성한_게시글.getId());
+
+            //then
+            verify(likeRepository, times(1)).save(postLikeCaptor.capture());
+
+            PostLike savedPostLike = postLikeCaptor.getValue();
+
+            assertThat(savedPostLike.getMember().getId()).isEqualTo(일반회원2.getId());
+            assertThat(savedPostLike.getPost().getId()).isEqualTo(일반회원1이_작성한_게시글.getId());
+        }
+    }
+
+
+    @Nested
+    @DisplayName("decreaseLikeCount() - 좋아요 감소 메서드 테스트")
+    class decreaseLikeCount{
+        @Test
+        @DisplayName("memberId와 postId로 좋아요 이력을 조회 했을 때, 좋아요를 누른 이력이 없는데, 좋아요를 감소시키려고 하는 경우 LikeDecreaseNotAllowedException 예외를 발생한다")
+        void test1() {
+            //given
+            when(likeRepository.findBy(any(Long.class), any(Long.class))).thenReturn(Optional.empty());
+
+            //when
+            assertThatThrownBy(() -> postLikeService.decreaseLikeCount(any(Long.class), any(Long.class)))
+                    .isInstanceOf(LikeDecreaseNotAllowedException.class);
+        }
+    }
+
+}

--- a/backend/src/test/java/com/daily/daily/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostServiceTest.java
@@ -3,7 +3,7 @@ package com.daily.daily.post.service;
 import com.daily.daily.common.service.S3StorageService;
 import com.daily.daily.member.repository.MemberRepository;
 import com.daily.daily.post.dto.PostRequestDTO;
-import com.daily.daily.post.dto.PostResponseDTO;
+import com.daily.daily.post.dto.PostWriteResponseDTO;
 import com.daily.daily.post.repository.PostRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -50,7 +50,7 @@ class PostServiceTest {
             when(postRepository.save(any())).thenReturn(일반회원1이_작성한_게시글());
 
             //when
-            PostResponseDTO result = postService.create(2L, new PostRequestDTO(), 다일리_페이지_이미지_파일());
+            PostWriteResponseDTO result = postService.create(2L, new PostRequestDTO(), 다일리_페이지_이미지_파일());
 
             //then
             verify(storageService, times(1)).uploadImage(any(), any(), any());
@@ -70,7 +70,7 @@ class PostServiceTest {
             when(postRepository.findById(POST_ID)).thenReturn(Optional.of(일반회원1이_작성한_게시글()));
 
             //when
-            PostResponseDTO updateResult = postService.update(POST_ID, new PostRequestDTO(), null);
+            PostWriteResponseDTO updateResult = postService.update(POST_ID, new PostRequestDTO(), null);
 
             //then
             assertThat(updateResult.getPageImage()).isEqualTo(일반회원1이_작성한_게시글().getPageImage());
@@ -85,7 +85,7 @@ class PostServiceTest {
             when(storageService.uploadImage(any(), any(), any())).thenReturn("post/4-awef-1231-xcvsdf-12312_qwf.png");
 
             //when
-            PostResponseDTO updateResult = postService.update(POST_ID, new PostRequestDTO(), 다일리_페이지_이미지_파일());
+            PostWriteResponseDTO updateResult = postService.update(POST_ID, new PostRequestDTO(), 다일리_페이지_이미지_파일());
 
             //then
             assertThat(updateResult.getPageImage()).isEqualTo("post/4-awef-1231-xcvsdf-12312_qwf.png");

--- a/backend/src/test/java/com/daily/daily/postcomment/repository/PostCommentRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/postcomment/repository/PostCommentRepositoryTest.java
@@ -10,6 +10,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
@@ -21,16 +23,13 @@ class PostCommentRepositoryTest {
     @Test
     @DisplayName("PageRequest에 맞게 슬라이스 객체를 반환하는지 확인한다.")
     void findAllByPostId() {
-        postRepository.save(Post.builder().build());
-        postRepository.save(Post.builder().build());
-        Post savedPost = postRepository.save(Post.builder().build()); // 저장된 postId는 3이다.
-
+        Post post = postRepository.save(Post.builder().build());
 
         //댓글 저장 (20개 저장)
         for (int i = 1; i <=20; i++) {
             PostComment postComment = PostComment.builder()
-                    .post(savedPost)
-                    .content(i + "번째" )
+                    .post(post)
+                    .content(i + "번째")
                     .build();
 
             commentRepository.save(postComment);
@@ -38,11 +37,13 @@ class PostCommentRepositoryTest {
 
         int pageNumber = 3;
         int pageSize = 5;
-        Slice<PostComment> comments = commentRepository.findByPostId(3L, PageRequest.of(pageNumber, pageSize));
+        Slice<PostComment> comments = commentRepository.findByPostId(post.getId(), PageRequest.of(pageNumber, pageSize));
 
         assertThat(comments.getSize()).isEqualTo(pageSize);
         assertThat(comments.getNumber()).isEqualTo(pageNumber);
-        assertThat(comments.hasNext()).isFalse();
-        assertThat(comments.getContent().get(1).getPostId()).isEqualTo(3L);
+        assertThat(comments.hasNext()).isFalse(); //총 댓글이 20개이므로 (pageNumber + 1) * pageSize = 20. 따라서 hasNext()는 false 이다.
+
+        List<PostComment> content = comments.getContent();
+        assertThat(content.get(1).getPostId()).isEqualTo(post.getId());
     }
 }


### PR DESCRIPTION
## 연관 이슈
close: #182 
## 작업 내용

- 게시글의 좋아요를 증가시킬 수 있다.
  - 이미 좋아요한 게시글에 좋아요 증가 요청을 보내면 예외를 처리한다.
- 게시글의 좋아요를 감소시킬 수 있다.
  - 좋아요를 누르지 않은 게시글에 좋아요 감소 요청을 보내면 예외를 처리한다.
- 게시글을 조회할 때 좋아요의 갯수도 같이 조회할 수 있다.

## 의논할 거리

## Merge 전에 해야할 작업

## 기타
