### PR TITLE
게시글에 해시태그 기능 추가 

### DIFF
--- a/backend/src/docs/asciidoc/api-document.adoc
+++ b/backend/src/docs/asciidoc/api-document.adoc
@@ -275,13 +275,13 @@ include::{snippets}/좋아요 증가/http-request.adoc[]
 
 ==== 응답
 
-include::{snippets}/좋아요 취소/http-response.adoc[]
+include::{snippets}/좋아요 증가/http-response.adoc[]
 
 === 좋아요 취소
 
 ==== 요청
 
-include::{snippets}/좋아요 증가/http-request.adoc[]
+include::{snippets}/좋아요 취소/http-request.adoc[]
 
 ==== 응답
 

--- a/backend/src/main/java/com/daily/daily/post/controller/PostController.java
+++ b/backend/src/main/java/com/daily/daily/post/controller/PostController.java
@@ -2,7 +2,7 @@ package com.daily.daily.post.controller;
 
 import com.daily.daily.common.dto.SuccessResponseDTO;
 import com.daily.daily.post.dto.PostReadResponseDTO;
-import com.daily.daily.post.dto.PostRequestDTO;
+import com.daily.daily.post.dto.PostWriteRequestDTO;
 import com.daily.daily.post.dto.PostWriteResponseDTO;
 import com.daily.daily.post.service.PostService;
 import jakarta.annotation.Nullable;
@@ -37,7 +37,7 @@ public class PostController {
     @ResponseStatus(HttpStatus.CREATED)
     public PostWriteResponseDTO createPost(
             @AuthenticationPrincipal Long id,
-            @RequestPart @Valid PostRequestDTO request,
+            @RequestPart @Valid PostWriteRequestDTO request,
             @RequestPart @NotNull MultipartFile pageImage
     ) {
         return postService.create(id, request, pageImage);
@@ -47,7 +47,7 @@ public class PostController {
     @Secured(value = "ROLE_MEMBER")
     public PostWriteResponseDTO updatePost(
             @PathVariable Long postId,
-            @RequestPart @Valid PostRequestDTO request,
+            @RequestPart @Valid PostWriteRequestDTO request,
             @RequestPart @Nullable MultipartFile pageImage
     ) {
         return postService.update(postId, request, pageImage);

--- a/backend/src/main/java/com/daily/daily/post/domain/Hashtag.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Hashtag.java
@@ -1,0 +1,28 @@
+package com.daily.daily.post.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class Hashtag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String tagName;
+
+    public static Hashtag of(String tagName) {
+        return new Hashtag(tagName);
+    }
+    private Hashtag (String tagName) {
+        this.tagName = tagName;
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -62,9 +62,9 @@ public class Post extends BaseTimeEntity {
         postHashtags.clear();
     }
 
-    public Set<String> getTagNames() {
+    public List<String> getTagNames() {
         return postHashtags.stream()
                 .map(PostHashtag::getTagName)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -17,14 +17,17 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Entity
 @Getter
-@AllArgsConstructor @Builder @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseTimeEntity {
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,9 +39,9 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member postWriter;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
-    private Set<PostHashtag> postHashtags = new HashSet<>();
+    private List<PostHashtag> postHashtags = new ArrayList<>();
 
     public void updatePageImage(String pageImage) {
         this.pageImage = pageImage;
@@ -46,5 +49,14 @@ public class Post extends BaseTimeEntity {
 
     public void updateContent(String content) {
         this.content = content;
+    }
+
+    public void addPostHashtag(PostHashtag postHashtag) {
+        postHashtags.add(postHashtag);
+        postHashtag.setPost(this);  // 연관관계 편의 로직.
+    }
+
+    public void clearHashtags() {
+        postHashtags.clear();
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -19,6 +19,8 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
 @Entity
@@ -58,5 +60,11 @@ public class Post extends BaseTimeEntity {
 
     public void clearHashtags() {
         postHashtags.clear();
+    }
+
+    public Set<String> getTagNames() {
+        return postHashtags.stream()
+                .map(PostHashtag::getTagName)
+                .collect(Collectors.toSet());
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -2,6 +2,7 @@ package com.daily.daily.post.domain;
 
 import com.daily.daily.common.domain.BaseTimeEntity;
 import com.daily.daily.member.domain.Member;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,11 +10,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
 
 
 @Entity
@@ -28,12 +33,12 @@ public class Post extends BaseTimeEntity {
     private String pageImage; // 이미지 파일 경로 저장
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "postId")
+    @JoinColumn(name = "member_id")
     private Member postWriter;
 
-//    @ManyToOne
-//    private HashTags hashTags
-
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @Builder.Default
+    private Set<PostHashtag> postHashtags = new HashSet<>();
 
     public void updatePageImage(String pageImage) {
         this.pageImage = pageImage;

--- a/backend/src/main/java/com/daily/daily/post/domain/PostHashtag.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/PostHashtag.java
@@ -1,0 +1,43 @@
+package com.daily.daily.post.domain;
+
+import com.daily.daily.common.domain.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostHashtag extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "hashtag_id")
+    private Hashtag hashtag;
+
+    private PostHashtag(Post post, Hashtag hashtag) {
+        this.post = post;
+        this.hashtag = hashtag;
+    }
+
+    public static PostHashtag of(Post post, Hashtag hashtag) {
+        PostHashtag postHashtag = new PostHashtag(post, hashtag);
+        post.getPostHashtags().add(postHashtag);
+
+        return new PostHashtag(post, hashtag);
+    }
+
+    public String getTangName() {
+        return hashtag.getTagName();
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/domain/PostHashtag.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/PostHashtag.java
@@ -2,26 +2,30 @@ package com.daily.daily.post.domain;
 
 import com.daily.daily.common.domain.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class PostHashtag extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @ManyToOne
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hashtag_id")
     private Hashtag hashtag;
 
@@ -31,13 +35,14 @@ public class PostHashtag extends BaseTimeEntity {
     }
 
     public static PostHashtag of(Post post, Hashtag hashtag) {
-        PostHashtag postHashtag = new PostHashtag(post, hashtag);
-        post.getPostHashtags().add(postHashtag);
-
         return new PostHashtag(post, hashtag);
     }
 
-    public String getTangName() {
+    public String getTagName() {
         return hashtag.getTagName();
+    }
+
+    public void setPost(Post post) {
+        this.post = post;
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/dto/PostReadResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostReadResponseDTO.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import java.util.Set;
+import java.util.List;
 
 @Getter
 @Setter
@@ -21,7 +21,7 @@ public class PostReadResponseDTO {
     private String pageImage;
     private Long writerId;
     private String writerNickname;
-    private Set<String> hashtags;
+    private List<String> hashtags;
     private Long likeCount;
     private LocalDateTime createdTime;
 

--- a/backend/src/main/java/com/daily/daily/post/dto/PostReadResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostReadResponseDTO.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.Set;
+
 @Getter
 @Setter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -19,6 +21,7 @@ public class PostReadResponseDTO {
     private String pageImage;
     private Long writerId;
     private String writerNickname;
+    private Set<String> hashtags;
     private Long likeCount;
     private LocalDateTime createdTime;
 
@@ -31,6 +34,7 @@ public class PostReadResponseDTO {
                 .pageImage(post.getPageImage())
                 .writerId(postWriter.getId())
                 .writerNickname(postWriter.getNickname())
+                .hashtags(post.getTagNames())
                 .createdTime(post.getCreatedTime())
                 .likeCount(likeCount)
                 .build();

--- a/backend/src/main/java/com/daily/daily/post/dto/PostRequestDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostRequestDTO.java
@@ -1,20 +1,22 @@
 package com.daily.daily.post.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-@Getter
+import java.util.Set;
+
 @Setter
+@Getter
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostRequestDTO {
-    @NotNull(message = "content 필드는 반드시 존재해야 합니다.")
+    @NotBlank(message = "content 필드는 반드시 존재해야 합니다.")
     private String content;
 
-//    private List<String> hashTag;
+    private Set<String> hashtags;
 }

--- a/backend/src/main/java/com/daily/daily/post/dto/PostWriteRequestDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostWriteRequestDTO.java
@@ -1,22 +1,23 @@
 package com.daily.daily.post.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 import java.util.Set;
 
-@Setter
 @Getter
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostWriteRequestDTO {
-    @NotBlank(message = "content 필드는 반드시 존재해야 합니다.")
+    @NotNull(message = "content 필드는 반드시 존재해야 합니다.")
     private String content;
 
+    @Size(max = 5, message = "게시글에 붙일 수 있는 해시태그는 최대 5개 입니다.")
     private Set<String> hashtags;
 }

--- a/backend/src/main/java/com/daily/daily/post/dto/PostWriteRequestDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostWriteRequestDTO.java
@@ -1,6 +1,5 @@
 package com.daily.daily.post.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/com/daily/daily/post/dto/PostWriteRequestDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostWriteRequestDTO.java
@@ -14,7 +14,7 @@ import java.util.Set;
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
-public class PostRequestDTO {
+public class PostWriteRequestDTO {
     @NotBlank(message = "content 필드는 반드시 존재해야 합니다.")
     private String content;
 

--- a/backend/src/main/java/com/daily/daily/post/dto/PostWriteResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostWriteResponseDTO.java
@@ -30,16 +30,12 @@ public class PostWriteResponseDTO { // 수정, 삭제 전용 응답 DTO
 
     public static PostWriteResponseDTO from(Post post) {
         Member postWriter = post.getPostWriter();
-        Set<String> hashtags = post.getPostHashtags()
-                .stream()
-                .map(PostHashtag::getTagName)
-                .collect(Collectors.toSet());
 
         return PostWriteResponseDTO.builder()
                 .postId(post.getId())
                 .content(post.getContent())
                 .pageImage(post.getPageImage())
-                .hashtags(hashtags)
+                .hashtags(post.getTagNames())
                 .writerId(postWriter.getId())
                 .writerNickname(postWriter.getNickname())
                 .createdTime(post.getCreatedTime())

--- a/backend/src/main/java/com/daily/daily/post/dto/PostWriteResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostWriteResponseDTO.java
@@ -2,6 +2,7 @@ package com.daily.daily.post.dto;
 
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.domain.PostHashtag;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +11,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -20,17 +23,23 @@ public class PostWriteResponseDTO { // 수정, 삭제 전용 응답 DTO
     private Long postId;
     private String content;
     private String pageImage;
+    private Set<String> hashtags;
     private Long writerId;
     private String writerNickname;
     private LocalDateTime createdTime;
 
     public static PostWriteResponseDTO from(Post post) {
         Member postWriter = post.getPostWriter();
+        Set<String> hashtags = post.getPostHashtags()
+                .stream()
+                .map(PostHashtag::getTangName)
+                .collect(Collectors.toSet());
 
         return PostWriteResponseDTO.builder()
                 .postId(post.getId())
                 .content(post.getContent())
                 .pageImage(post.getPageImage())
+                .hashtags(hashtags)
                 .writerId(postWriter.getId())
                 .writerNickname(postWriter.getNickname())
                 .createdTime(post.getCreatedTime())

--- a/backend/src/main/java/com/daily/daily/post/dto/PostWriteResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostWriteResponseDTO.java
@@ -2,7 +2,6 @@ package com.daily.daily.post.dto;
 
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.post.domain.Post;
-import com.daily.daily.post.domain.PostHashtag;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,8 +10,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Getter
 @Setter
@@ -23,7 +21,7 @@ public class PostWriteResponseDTO { // 수정, 삭제 전용 응답 DTO
     private Long postId;
     private String content;
     private String pageImage;
-    private Set<String> hashtags;
+    private List<String> hashtags;
     private Long writerId;
     private String writerNickname;
     private LocalDateTime createdTime;

--- a/backend/src/main/java/com/daily/daily/post/dto/PostWriteResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostWriteResponseDTO.java
@@ -32,7 +32,7 @@ public class PostWriteResponseDTO { // 수정, 삭제 전용 응답 DTO
         Member postWriter = post.getPostWriter();
         Set<String> hashtags = post.getPostHashtags()
                 .stream()
-                .map(PostHashtag::getTangName)
+                .map(PostHashtag::getTagName)
                 .collect(Collectors.toSet());
 
         return PostWriteResponseDTO.builder()

--- a/backend/src/main/java/com/daily/daily/post/repository/HashtagRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/HashtagRepository.java
@@ -8,7 +8,5 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
-    boolean existsByTagName(String tagName);
-
     Optional<Hashtag> findByTagName(String tagName);
 }

--- a/backend/src/main/java/com/daily/daily/post/repository/HashtagRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/HashtagRepository.java
@@ -1,0 +1,14 @@
+package com.daily.daily.post.repository;
+
+import com.daily.daily.post.domain.Hashtag;
+import org.springframework.data.domain.Example;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+    boolean existsByTagName(String tagName);
+
+    Optional<Hashtag> findByTagName(String tagName);
+}

--- a/backend/src/main/java/com/daily/daily/post/repository/PostHashtagRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostHashtagRepository.java
@@ -1,0 +1,7 @@
+package com.daily.daily.post.repository;
+
+import com.daily.daily.post.domain.PostHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
+}

--- a/backend/src/main/java/com/daily/daily/post/service/HashtagService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/HashtagService.java
@@ -33,7 +33,7 @@ public class HashtagService {
     }
 
     private Set<String> getDefaultHashtagsIfEmpty(Set<String> hashtags) {
-        if (hashtags == null || hashtags.isEmpty()) {
+        if (hashtags == null || hashtags.isEmpty() || hashtags.stream().allMatch(String::isBlank)) {
             hashtags = Set.of(DEFAULT_HASHTAG);
         }
         return hashtags;

--- a/backend/src/main/java/com/daily/daily/post/service/HashtagService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/HashtagService.java
@@ -4,7 +4,6 @@ import com.daily.daily.post.domain.Hashtag;
 import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.domain.PostHashtag;
 import com.daily.daily.post.repository.HashtagRepository;
-import com.daily.daily.post.repository.PostHashtagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,22 +15,36 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional
 public class HashtagService {
+    private static final String DEFAULT_HASHTAG = "일반";
+
     private final HashtagRepository hashtagRepository;
 
-    private final PostHashtagRepository postHashtagRepository;
-
     public void addHashtagsToPost(Post post, Set<String> hashtags) {
-        Set<Hashtag> hashtagEntities = findHashTagsOrSave(hashtags);
-        hashtagEntities.forEach(hashtag -> postHashtagRepository.save(PostHashtag.of(post, hashtag)));
+        Set<Hashtag> hashtagEntities = findHashtagsOrCreate(hashtags);
+        hashtagEntities.forEach(hashtagEntity -> post.addPostHashtag(PostHashtag.of(post, hashtagEntity)));
     }
 
-    private Set<Hashtag> findHashTagsOrSave(Set<String> hashtags) {
-        if (hashtags == null || hashtags.isEmpty()) {
-            hashtags = Set.of("일반");
-        }
+    private Set<Hashtag> findHashtagsOrCreate(Set<String> hashtags) {
+        hashtags = getDefaultHashtagsIfEmpty(hashtags);
 
         return hashtags.stream()
-                .map(hashtag -> hashtagRepository.findByTagName(hashtag).orElse(hashtagRepository.save(Hashtag.of(hashtag))))
+                .map(tagName -> hashtagRepository.findByTagName(tagName).orElseGet(() -> createHashtag(tagName)))
                 .collect(Collectors.toSet());
+    }
+
+    private Set<String> getDefaultHashtagsIfEmpty(Set<String> hashtags) {
+        if (hashtags == null || hashtags.isEmpty()) {
+            hashtags = Set.of(DEFAULT_HASHTAG);
+        }
+        return hashtags;
+    }
+
+    public void updateHashtagsInPost(Post post, Set<String> hashtags) {
+        post.clearHashtags();
+        addHashtagsToPost(post, hashtags);
+    }
+
+    private Hashtag createHashtag(String tagName) {
+        return hashtagRepository.save(Hashtag.of(tagName));
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/service/HashtagService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/HashtagService.java
@@ -40,6 +40,13 @@ public class HashtagService {
     }
 
     public void updateHashtagsInPost(Post post, Set<String> hashtags) {
+        /**
+         * 현재 코드는 기존 post가 가지고 있는 해시태그의 갯수만큼 delete 쿼리가 발생한다.
+         * 쿼리를 최소화 하고싶으면, 게시글에 있는 해시태그가 수정목록에 존재하지 않으면 목록에서 지우고, 꼭 추가해야만 하는 해시태그만 add 해주면 된다.
+         * 대신 이러면 코드가 15줄은 더 늘어난다.ㅠ ㅠ
+         */
+
+
         post.clearHashtags();
         addHashtagsToPost(post, hashtags);
     }

--- a/backend/src/main/java/com/daily/daily/post/service/HashtagService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/HashtagService.java
@@ -1,0 +1,37 @@
+package com.daily.daily.post.service;
+
+import com.daily.daily.post.domain.Hashtag;
+import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.domain.PostHashtag;
+import com.daily.daily.post.repository.HashtagRepository;
+import com.daily.daily.post.repository.PostHashtagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HashtagService {
+    private final HashtagRepository hashtagRepository;
+
+    private final PostHashtagRepository postHashtagRepository;
+
+    public void addHashtagsToPost(Post post, Set<String> hashtags) {
+        Set<Hashtag> hashtagEntities = findHashTagsOrSave(hashtags);
+        hashtagEntities.forEach(hashtag -> postHashtagRepository.save(PostHashtag.of(post, hashtag)));
+    }
+
+    private Set<Hashtag> findHashTagsOrSave(Set<String> hashtags) {
+        if (hashtags == null || hashtags.isEmpty()) {
+            hashtags = Set.of("일반");
+        }
+
+        return hashtags.stream()
+                .map(hashtag -> hashtagRepository.findByTagName(hashtag).orElse(hashtagRepository.save(Hashtag.of(hashtag))))
+                .collect(Collectors.toSet());
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/service/PostService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostService.java
@@ -56,6 +56,7 @@ public class PostService {
                 .orElseThrow(PostNotFoundException::new);
 
         post.updateContent(postWriteRequestDTO.getContent());
+        hashtagService.updateHashtagsInPost(post, postWriteRequestDTO.getHashtags());
 
         if (pageImage == null || pageImage.isEmpty()) {
             return PostWriteResponseDTO.from(post);
@@ -80,5 +81,4 @@ public class PostService {
     public void delete(Long postId) {
         postRepository.deleteById(postId);
     }
-
 }

--- a/backend/src/main/java/com/daily/daily/post/service/PostService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostService.java
@@ -4,15 +4,11 @@ import com.daily.daily.common.service.S3StorageService;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.member.exception.MemberNotFoundException;
 import com.daily.daily.member.repository.MemberRepository;
-import com.daily.daily.post.domain.Hashtag;
-import com.daily.daily.post.domain.PostHashtag;
-import com.daily.daily.post.repository.HashtagRepository;
 import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.dto.PostReadResponseDTO;
-import com.daily.daily.post.dto.PostRequestDTO;
+import com.daily.daily.post.dto.PostWriteRequestDTO;
 import com.daily.daily.post.dto.PostWriteResponseDTO;
 import com.daily.daily.post.exception.PostNotFoundException;
-import com.daily.daily.post.repository.PostHashtagRepository;
 import com.daily.daily.post.repository.PostLikeRepository;
 import com.daily.daily.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +18,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.Set;
 
 @Service
 @Transactional
@@ -41,26 +36,26 @@ public class PostService {
 
     private final HashtagService hashtagService;
 
-    public PostWriteResponseDTO create(Long memberId, PostRequestDTO postRequestDTO, MultipartFile pageImage) {
+    public PostWriteResponseDTO create(Long memberId, PostWriteRequestDTO postWriteRequestDTO, MultipartFile pageImage) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
         Post post = Post.builder()
-                .content(postRequestDTO.getContent())
+                .content(postWriteRequestDTO.getContent())
                 .postWriter(member)
                 .build();
 
         Post savedPost = postRepository.save(post);
-        hashtagService.addHashtagsToPost(savedPost, postRequestDTO.getHashtags());
+        hashtagService.addHashtagsToPost(savedPost, postWriteRequestDTO.getHashtags());
 
         uploadPageImage(savedPost, pageImage);
         return PostWriteResponseDTO.from(savedPost);
     }
 
-    public PostWriteResponseDTO update(Long postId, PostRequestDTO postRequestDTO, MultipartFile pageImage) {
+    public PostWriteResponseDTO update(Long postId, PostWriteRequestDTO postWriteRequestDTO, MultipartFile pageImage) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(PostNotFoundException::new);
 
-        post.updateContent(postRequestDTO.getContent());
+        post.updateContent(postWriteRequestDTO.getContent());
 
         if (pageImage == null || pageImage.isEmpty()) {
             return PostWriteResponseDTO.from(post);

--- a/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
+++ b/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
@@ -10,6 +10,7 @@ import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingExcept
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 import static com.daily.daily.member.fixture.MemberFixture.일반회원1;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -25,7 +26,7 @@ public class PostFixture {
 
 
     public static PostRequestDTO 게시글_요청_DTO() {
-        return new PostRequestDTO(POST_CONTENT);
+        return new PostRequestDTO(POST_CONTENT, Set.of("일반", "음식", "대학생"));
     }
 
     public static PostWriteResponseDTO 게시글_작성_응답_DTO() {

--- a/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
+++ b/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
@@ -3,7 +3,7 @@ package com.daily.daily.post.fixture;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.dto.PostReadResponseDTO;
-import com.daily.daily.post.dto.PostRequestDTO;
+import com.daily.daily.post.dto.PostWriteRequestDTO;
 import com.daily.daily.post.dto.PostWriteResponseDTO;
 import org.springframework.mock.web.MockMultipartFile;
 import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,8 +25,8 @@ public class PostFixture {
     private static final LocalDateTime POST_CREATED_TIME = LocalDateTime.of(2024,1,18,15,38,32,42);
 
 
-    public static PostRequestDTO 게시글_요청_DTO() {
-        return new PostRequestDTO(POST_CONTENT, Set.of("일반", "음식", "대학생"));
+    public static PostWriteRequestDTO 게시글_요청_DTO() {
+        return new PostWriteRequestDTO(POST_CONTENT, Set.of("일반", "음식", "대학생"));
     }
 
     public static PostWriteResponseDTO 게시글_작성_응답_DTO() {

--- a/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
+++ b/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
@@ -10,6 +10,7 @@ import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingExcept
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.Set;
 
 import static com.daily.daily.member.fixture.MemberFixture.일반회원1;
@@ -23,7 +24,6 @@ public class PostFixture {
     private static final String POST_CONTENT = "오늘 저의 다일리입니다.";
     private static final String PAGE_IMAGE_URL = "imageURL";
     private static final LocalDateTime POST_CREATED_TIME = LocalDateTime.of(2024,1,18,15,38,32,42);
-
 
     public static PostWriteRequestDTO 게시글_요청_DTO() {
         return new PostWriteRequestDTO(POST_CONTENT, Set.of("일반", "음식", "대학생"));

--- a/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
+++ b/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
@@ -1,7 +1,9 @@
 package com.daily.daily.post.fixture;
 
 import com.daily.daily.member.domain.Member;
+import com.daily.daily.post.domain.Hashtag;
 import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.domain.PostHashtag;
 import com.daily.daily.post.dto.PostReadResponseDTO;
 import com.daily.daily.post.dto.PostWriteRequestDTO;
 import com.daily.daily.post.dto.PostWriteResponseDTO;
@@ -10,8 +12,9 @@ import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingExcept
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.Set;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.daily.daily.member.fixture.MemberFixture.일반회원1;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -24,9 +27,13 @@ public class PostFixture {
     private static final String POST_CONTENT = "오늘 저의 다일리입니다.";
     private static final String PAGE_IMAGE_URL = "imageURL";
     private static final LocalDateTime POST_CREATED_TIME = LocalDateTime.of(2024,1,18,15,38,32,42);
+    private static final List<String> HASHTAG_NAMES = List.of("일반", "음식", "대학생");
+    private static final List<Hashtag> HASHTAGS = HASHTAG_NAMES.stream()
+            .map(Hashtag::of)
+            .toList();
 
     public static PostWriteRequestDTO 게시글_요청_DTO() {
-        return new PostWriteRequestDTO(POST_CONTENT, Set.of("일반", "음식", "대학생"));
+        return new PostWriteRequestDTO(POST_CONTENT, new HashSet<>(HASHTAG_NAMES));
     }
 
     public static PostWriteResponseDTO 게시글_작성_응답_DTO() {
@@ -38,6 +45,7 @@ public class PostFixture {
                 .pageImage(PAGE_IMAGE_URL)
                 .writerId(member.getId())
                 .writerNickname(member.getNickname())
+                .hashtags(HASHTAG_NAMES)
                 .createdTime(POST_CREATED_TIME)
                 .build();
     }
@@ -49,9 +57,10 @@ public class PostFixture {
                 .postId(게시글_작성_응답_DTO.getPostId())
                 .content(게시글_작성_응답_DTO.getContent())
                 .pageImage(게시글_작성_응답_DTO.getPageImage())
-                .writerId(게시글_작성_응답_DTO().getWriterId())
-                .writerNickname(게시글_작성_응답_DTO().getWriterNickname())
-                .createdTime(게시글_작성_응답_DTO().getCreatedTime())
+                .writerId(게시글_작성_응답_DTO.getWriterId())
+                .writerNickname(게시글_작성_응답_DTO.getWriterNickname())
+                .hashtags(게시글_작성_응답_DTO.getHashtags())
+                .createdTime(게시글_작성_응답_DTO.getCreatedTime())
                 .likeCount(10L)
                 .build();
     }
@@ -75,11 +84,15 @@ public class PostFixture {
     }
 
     public static Post 일반회원1이_작성한_게시글() {
-        return Post.builder()
+        Post post = Post.builder()
                 .id(3L)
                 .content(POST_CONTENT)
                 .pageImage(PAGE_IMAGE_URL)
                 .postWriter(일반회원1())
                 .build();
+
+        HASHTAGS.forEach(hashtag -> post.addPostHashtag(PostHashtag.of(post, hashtag)));
+
+        return post;
     }
 }

--- a/backend/src/test/java/com/daily/daily/post/service/HashtagServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/HashtagServiceTest.java
@@ -1,0 +1,138 @@
+package com.daily.daily.post.service;
+
+import com.daily.daily.post.domain.Hashtag;
+import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.domain.PostHashtag;
+import com.daily.daily.post.repository.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @Mock
+    HashtagRepository hashtagRepository;
+    @InjectMocks
+    HashtagService hashtagService;
+
+    @Nested
+    @DisplayName("addHashtagsToPost() - 게시글에 해시태그 추가 메서드 테스트")
+    class addHashtagsToPost {
+
+        @Test
+        @DisplayName("해시태그 목록들이 비어있으면, DEFAULT_HASHTAGS 인 '일반' 해시태그를 붙여줘야 한다. ")
+        void test1() {
+            //given
+            Set<String> emptyHashtags = Set.of("");
+            Post post = Post.builder().build();
+
+            when(hashtagRepository.findByTagName("일반")).thenReturn(Optional.of(Hashtag.of("일반")));
+
+            //when
+            hashtagService.addHashtagsToPost(post, emptyHashtags);
+
+            //then
+            assertThat(post.getPostHashtags().size()).isEqualTo(1);
+            assertThat(post.getPostHashtags().get(0).getTagName()).isEqualTo("일반");
+        }
+
+        @Test
+        @DisplayName("인자에 들어오는 해시태그 목록에 맞춰서, 게시글에 해시태그들이 추가되어야 한다.")
+        void test2() {
+            //given
+            Set<String> hashtags = Set.of("일상", "점심", "학식");
+            Post post = Post.builder().build();
+
+            when(hashtagRepository.findByTagName("일상")).thenReturn(Optional.of(Hashtag.of("일상")));
+            when(hashtagRepository.findByTagName("점심")).thenReturn(Optional.of(Hashtag.of("점심")));
+            when(hashtagRepository.findByTagName("학식")).thenReturn(Optional.of(Hashtag.of("학식")));
+
+            //when
+            hashtagService.addHashtagsToPost(post, hashtags);
+
+            //then
+            assertThat(post.getPostHashtags().size()).isEqualTo(3);
+
+            Set<String> resultHashtags = post.getPostHashtags().stream()
+                    .map(PostHashtag::getTagName)
+                    .collect(Collectors.toSet());
+
+            assertThat(resultHashtags).isEqualTo(hashtags);
+        }
+
+        @Test
+        @DisplayName("인자로 들어오는 해시태그가 DB에 등록되지 않은 해시태그라면 HashtagRepository.save()를 호출해서 추가해야 한다.")
+        void test3() {
+            //given
+            Set<String> hashtags = Set.of("일상", "점심", "학식");
+            Post post = Post.builder().build();
+
+            when(hashtagRepository.findByTagName(any())).thenReturn(Optional.empty());
+
+            //when
+            hashtagService.addHashtagsToPost(post, hashtags);
+
+            //then
+            verify(hashtagRepository, times(3)).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateHashtagsInPost() - 게시글에 있는 해시태그 수정 메서드 테스트")
+    class updateHashtagsInPost {
+        @Test
+        @DisplayName("인자로 들어오는 해시태그 목록이 비어있으면, DEFAULT_HASHTAGS 인 '일반' 해시태그를 붙여줘야 한다.")
+        void test1() {
+            //given
+            Set<String> emptyHashtags = Set.of("");
+            Post post = Post.builder().build();
+
+            when(hashtagRepository.findByTagName("일반")).thenReturn(Optional.of(Hashtag.of("일반")));
+
+            //when
+            hashtagService.updateHashtagsInPost(post, emptyHashtags);
+
+            //then
+            assertThat(post.getPostHashtags().size()).isEqualTo(1);
+            assertThat(post.getPostHashtags().get(0).getTagName()).isEqualTo("일반");
+        }
+
+        @Test
+        @DisplayName("인자로 들어오는 해시태그 목록과 일치하게 Post에 해시태그들이 추가되어야만 한다.")
+        void test2() {
+            //given
+            Set<String> hashtags = Set.of("시험기간", "대학생");
+            Post post = Post.builder().build();
+
+            when(hashtagRepository.findByTagName("시험기간")).thenReturn(Optional.of(Hashtag.of("시험기간")));
+            when(hashtagRepository.findByTagName("대학생")).thenReturn(Optional.of(Hashtag.of("대학생")));
+
+            //when
+            hashtagService.updateHashtagsInPost(post, hashtags);
+
+            //then
+            assertThat(post.getPostHashtags().size()).isEqualTo(2);
+
+            Set<String> resultHashtags = post.getPostHashtags().stream()
+                    .map(PostHashtag::getTagName)
+                    .collect(Collectors.toSet());
+
+            assertThat(resultHashtags).isEqualTo(hashtags);
+        }
+    }
+}

--- a/backend/src/test/java/com/daily/daily/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostServiceTest.java
@@ -2,7 +2,7 @@ package com.daily.daily.post.service;
 
 import com.daily.daily.common.service.S3StorageService;
 import com.daily.daily.member.repository.MemberRepository;
-import com.daily.daily.post.dto.PostRequestDTO;
+import com.daily.daily.post.dto.PostWriteRequestDTO;
 import com.daily.daily.post.dto.PostWriteResponseDTO;
 import com.daily.daily.post.repository.PostRepository;
 import org.assertj.core.api.Assertions;
@@ -52,7 +52,7 @@ class PostServiceTest {
             when(postRepository.save(any())).thenReturn(일반회원1이_작성한_게시글());
 
             //when
-            PostWriteResponseDTO result = postService.create(2L, new PostRequestDTO(), 다일리_페이지_이미지_파일());
+            PostWriteResponseDTO result = postService.create(2L, new PostWriteRequestDTO(), 다일리_페이지_이미지_파일());
 
             //then
             verify(storageService, times(1)).uploadImage(any(), any(), any());
@@ -72,7 +72,7 @@ class PostServiceTest {
             when(postRepository.findById(POST_ID)).thenReturn(Optional.of(일반회원1이_작성한_게시글()));
 
             //when
-            PostWriteResponseDTO updateResult = postService.update(POST_ID, new PostRequestDTO(), null);
+            PostWriteResponseDTO updateResult = postService.update(POST_ID, new PostWriteRequestDTO(), null);
 
             //then
             assertThat(updateResult.getPageImage()).isEqualTo(일반회원1이_작성한_게시글().getPageImage());
@@ -87,7 +87,7 @@ class PostServiceTest {
             when(storageService.uploadImage(any(), any(), any())).thenReturn("post/4-awef-1231-xcvsdf-12312_qwf.png");
 
             //when
-            PostWriteResponseDTO updateResult = postService.update(POST_ID, new PostRequestDTO(), 다일리_페이지_이미지_파일());
+            PostWriteResponseDTO updateResult = postService.update(POST_ID, new PostWriteRequestDTO(), 다일리_페이지_이미지_파일());
 
             //then
             assertThat(updateResult.getPageImage()).isEqualTo("post/4-awef-1231-xcvsdf-12312_qwf.png");

--- a/backend/src/test/java/com/daily/daily/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostServiceTest.java
@@ -2,8 +2,11 @@ package com.daily.daily.post.service;
 
 import com.daily.daily.common.service.S3StorageService;
 import com.daily.daily.member.repository.MemberRepository;
+import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.dto.PostReadResponseDTO;
 import com.daily.daily.post.dto.PostWriteRequestDTO;
 import com.daily.daily.post.dto.PostWriteResponseDTO;
+import com.daily.daily.post.repository.PostLikeRepository;
 import com.daily.daily.post.repository.PostRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -13,10 +16,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
 import java.util.Optional;
 
 import static com.daily.daily.member.fixture.MemberFixture.일반회원1;
 import static com.daily.daily.post.fixture.PostFixture.POST_ID;
+import static com.daily.daily.post.fixture.PostFixture.게시글_요청_DTO;
 import static com.daily.daily.post.fixture.PostFixture.다일리_페이지_이미지_파일;
 import static com.daily.daily.post.fixture.PostFixture.일반회원1이_작성한_게시글;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,6 +42,8 @@ class PostServiceTest {
     S3StorageService storageService;
     @Mock
     HashtagService hashtagService;
+    @Mock
+    PostLikeRepository likeRepository;
     @InjectMocks
     PostService postService;
 
@@ -47,17 +55,22 @@ class PostServiceTest {
                 "그리고 PostResponse의 페이지 이미지 URL 경로는 storageService.uploadImage() 의 반환값으로 받은 URL 경로와 일치한다.")
         void test1() {
             //given
+            PostWriteRequestDTO 게시글_작성_요청_DTO = 게시글_요청_DTO();
+            Post 일반회원1이_작성한_게시글 = 일반회원1이_작성한_게시글();
+
             when(memberRepository.findById(any())).thenReturn(Optional.of(일반회원1()));
             when(storageService.uploadImage(any(), any(), any())).thenReturn("post/3-awef-123-124-wafewe123123_asdf.png");
-            when(postRepository.save(any())).thenReturn(일반회원1이_작성한_게시글());
+            when(postRepository.save(any())).thenReturn(일반회원1이_작성한_게시글);
 
             //when
-            PostWriteResponseDTO result = postService.create(2L, new PostWriteRequestDTO(), 다일리_페이지_이미지_파일());
+            PostWriteResponseDTO result = postService.create(2L, 게시글_작성_요청_DTO, 다일리_페이지_이미지_파일());
 
             //then
             verify(storageService, times(1)).uploadImage(any(), any(), any());
             verify(postRepository, times(1)).save(any());
-            Assertions.assertThat(result.getPageImage()).isEqualTo("post/3-awef-123-124-wafewe123123_asdf.png");
+            verify(hashtagService, times(1)).addHashtagsToPost(일반회원1이_작성한_게시글, 게시글_작성_요청_DTO.getHashtags());
+            assertThat(result.getPageImage()).isEqualTo("post/3-awef-123-124-wafewe123123_asdf.png");
+            assertThat(new HashSet<>(result.getHashtags())).isEqualTo(게시글_작성_요청_DTO.getHashtags());
         }
     }
 
@@ -91,6 +104,25 @@ class PostServiceTest {
 
             //then
             assertThat(updateResult.getPageImage()).isEqualTo("post/4-awef-1231-xcvsdf-12312_qwf.png");
+        }
+    }
+
+    @Nested
+    @DisplayName("find() - 게시글 단건 조회 테스트")
+    class find {
+
+        @Test
+        @DisplayName("likeRepository에서 반환한 좋아요 갯수와, 반환하는 DTO의 좋아요 갯수는 같아야한다.")
+        void test1() {
+            //given
+            when(postRepository.findById(any())).thenReturn(Optional.of(일반회원1이_작성한_게시글()));
+            when(likeRepository.countByPost(any())).thenReturn(5L);
+
+            //when
+            PostReadResponseDTO result = postService.find(POST_ID);
+
+            //then
+            assertThat(result.getLikeCount()).isEqualTo(5L);
         }
     }
 }

--- a/backend/src/test/java/com/daily/daily/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostServiceTest.java
@@ -34,6 +34,8 @@ class PostServiceTest {
     MemberRepository memberRepository;
     @Mock
     S3StorageService storageService;
+    @Mock
+    HashtagService hashtagService;
     @InjectMocks
     PostService postService;
 


### PR DESCRIPTION
## 연관 이슈
close: #189 
## 작업 내용
- 게시글 업로드시 해시태그를 붙일 수 있다.
- 게시글의 해시태그를 수정할 수 있다.
- 게시글의 해시태그를 삭제할 수 있다.
- 게시글 조회시 해시태그를 같이 조회할 수 있다.

## 의논할 거리
## Merge 전에 해야할 작업
## 기타

- JPA 양방향 연관관계를 적용하면서 삽질을 좀 많이 해서 늦었네요.. 관련해서 위키에 작성할게요
- 해시태그 수정 로직은, 우선은 delete로 싹 지우고 추가하는 방식으로 했습니다. 대신 최적화 할 수 있는 방안에 대해서 주석을 조금 남겼습니다.