### PR TITLE
좋아요 갯수 최적화하기

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,13 @@ dependencies {
 	implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.0'
 	implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations'
 
+	//querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	//aws
 	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.0")
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
 	//jwt library
@@ -102,7 +109,12 @@ tasks.register('copySubmoduleYml', Copy) {
 	}
 }
 
+//querydsl Q타입 비우기 (clean)
+clean {
+	delete file('src/main/generated')
+}
 
 jar {
 	enabled = false
 }
+

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	implementation 'com.auth0:java-jwt:4.2.1'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/backend/src/main/java/com/daily/daily/common/config/QuerydslConfig.java
+++ b/backend/src/main/java/com/daily/daily/common/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.daily.daily.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageUpdateDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageUpdateDTO.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.Value;
 
 import java.util.List;
 import java.util.Map;
@@ -45,7 +44,7 @@ public class DailryPageUpdateDTO {
 
         @NotBlank(message = "rotation 값은 비어있을 수 없습니다.")
         private String rotation;
-        private Map<String, Object> properties;
+        private Map<String, Object> typeContent;
 
         @Getter
         @Setter

--- a/backend/src/main/java/com/daily/daily/member/domain/Member.java
+++ b/backend/src/main/java/com/daily/daily/member/domain/Member.java
@@ -16,7 +16,6 @@ public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
     private Long id;
     private String username;
     private String password;

--- a/backend/src/main/java/com/daily/daily/post/repository/PostHashtagRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostHashtagRepository.java
@@ -1,7 +1,0 @@
-package com.daily.daily.post.repository;
-
-import com.daily.daily.post.domain.PostHashtag;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
-}

--- a/backend/src/main/java/com/daily/daily/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostRepository.java
@@ -1,17 +1,8 @@
 package com.daily.daily.post.repository;
 
 import com.daily.daily.post.domain.Post;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryQuerydsl {
 
-    @Query("select p from Post p " +
-            "left join fetch p.postWriter pw " +
-            "left join fetch p.postHashtags ph " +
-            "left join fetch ph.hashtag h"
-    )
-    Slice<Post> find(Pageable pageable);
 }

--- a/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydsl.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydsl.java
@@ -1,0 +1,11 @@
+package com.daily.daily.post.repository;
+
+import com.daily.daily.post.domain.Post;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface PostRepositoryQuerydsl {
+
+    Slice<Post> find(Pageable pageable);
+
+}

--- a/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydslImpl.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydslImpl.java
@@ -50,9 +50,9 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
 
     private List<Long> getLikeCounts(Pageable pageable) {
         return em.createNativeQuery(
-                        "SELECT COUNT(postlike.id) " +
+                        "SELECT COUNT(post_like.id) " +
                                 "FROM post " +
-                                "LEFT JOIN postlike ON post.id = postlike.post_id " +
+                                "LEFT JOIN post_like ON post.id = post_like.post_id " +
                                 "GROUP BY post.id " +
                                 "ORDER BY post.id ASC " +
                                 "LIMIT :pageSize OFFSET :offset", Long.class)

--- a/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydslImpl.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydslImpl.java
@@ -28,7 +28,7 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
         List<Post> posts = queryFactory
                 .selectFrom(post)
                 .leftJoin(post.postWriter, member).fetchJoin()
-                .orderBy(post.id.asc())
+                .orderBy(post.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
@@ -43,8 +43,6 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
             posts.get(i).setLikeCount(likeCounts.get(i));
         }
 
-        System.out.println("querydsl test");
-
         return new SliceImpl<>(posts ,pageable, hasNext);
     }
 
@@ -54,7 +52,7 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
                                 "FROM post " +
                                 "LEFT JOIN post_like ON post.id = post_like.post_id " +
                                 "GROUP BY post.id " +
-                                "ORDER BY post.id ASC " +
+                                "ORDER BY post.id DESC " +
                                 "LIMIT :pageSize OFFSET :offset", Long.class)
                 .setParameter("pageSize", pageable.getPageSize())
                 .setParameter("offset", pageable.getOffset())

--- a/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydslImpl.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydslImpl.java
@@ -1,0 +1,63 @@
+package com.daily.daily.post.repository;
+
+import com.daily.daily.post.domain.Post;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.daily.daily.member.domain.QMember.member;
+import static com.daily.daily.post.domain.QPost.post;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final EntityManager em;
+
+    @Override
+    public Slice<Post> find(Pageable pageable) {
+        List<Long> likeCounts = getLikeCounts(pageable);
+        List<Post> posts = queryFactory
+                .selectFrom(post)
+                .leftJoin(post.postWriter, member).fetchJoin()
+                .orderBy(post.id.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = posts.size() > pageable.getPageSize(); // 다음 페이지 여부 확인
+
+        if (hasNext) {
+            posts.remove(posts.size() - 1); // 마지막 항목 제거
+        }
+
+        for (int i = 0; i < posts.size(); i++) {
+            posts.get(i).setLikeCount(likeCounts.get(i));
+        }
+
+        System.out.println("querydsl test");
+
+        return new SliceImpl<>(posts ,pageable, hasNext);
+    }
+
+    private List<Long> getLikeCounts(Pageable pageable) {
+        return em.createNativeQuery(
+                        "SELECT COUNT(postlike.id) " +
+                                "FROM post " +
+                                "LEFT JOIN postlike ON post.id = postlike.post_id " +
+                                "GROUP BY post.id " +
+                                "ORDER BY post.id ASC " +
+                                "LIMIT :pageSize OFFSET :offset", Long.class)
+                .setParameter("pageSize", pageable.getPageSize())
+                .setParameter("offset", pageable.getOffset())
+                .getResultList();
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/service/PostService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostService.java
@@ -86,14 +86,6 @@ public class PostService {
     public PostReadSliceResponseDTO findSlice(Pageable pageable) {
         Slice<Post> posts = postRepository.find(pageable);
 
-        /**
-         * TODO: 이렇게 하면 좋아요 갯수를 조회하기 위해 N+1쿼리가 발생한다. 따라서 최적화가 필요한데... 어떻게 처리할 지 고민이다.
-         */
-        for (Post post : posts) {
-            Long likeCount = likeRepository.countByPost(post);
-            post.setLikeCount(likeCount);
-        }
-
         return PostReadSliceResponseDTO.from(posts);
     }
 

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -550,8 +550,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA2NzE1NjkwfQ.nlkbEgopf39z8uc3b5wf1Sz83eeseedKd22_ENoLqWeyIZe8peKiEgCm2pVltnEzeWOmJqU9RwwEVFhdBbcmWg
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwNjcxMjA5MCwiZXhwIjoxNzA3OTIxNjkwfQ.zYLli-uR8CulUalpRtUXzC3BWuPtJhcfoIlh5chFzzEgTAMUqwSxrahUe7oGPwfdkjw3FOvMJ9puqR-TYP4-RA
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA2ODAyNDkwfQ.7HhXhKULTZYOwl4cqoRl5ObyBHe--f6OFZ-Zum_5ph8xL9ITTDygrdkQbri_KQGJ0tysBVqg2mxeJskv6dB66Q
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwNjc5ODg5MCwiZXhwIjoxNzA4MDA4NDkwfQ.zvQGmJENJv1pQNd8ehnWanozgP_xlGtx16iAK8LgMEPtXuxawU_hdn5TwFHLSdrrOK0t0AZIhGJWW2N3-_OGsg
 
 {
   "username" : "testtest",
@@ -595,8 +595,8 @@ Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwNjcxMj
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA2NzE1NjkwfQ.nlkbEgopf39z8uc3b5wf1Sz83eeseedKd22_ENoLqWeyIZe8peKiEgCm2pVltnEzeWOmJqU9RwwEVFhdBbcmWg; Path=/; Secure; HttpOnly; SameSite=None
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwNjcxMjA5MCwiZXhwIjoxNzA3OTIxNjkwfQ.zYLli-uR8CulUalpRtUXzC3BWuPtJhcfoIlh5chFzzEgTAMUqwSxrahUe7oGPwfdkjw3FOvMJ9puqR-TYP4-RA; Path=/; Secure; HttpOnly; SameSite=None
+Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA2ODAyNDkwfQ.7HhXhKULTZYOwl4cqoRl5ObyBHe--f6OFZ-Zum_5ph8xL9ITTDygrdkQbri_KQGJ0tysBVqg2mxeJskv6dB66Q; Path=/; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwNjc5ODg5MCwiZXhwIjoxNzA4MDA4NDkwfQ.zvQGmJENJv1pQNd8ehnWanozgP_xlGtx16iAK8LgMEPtXuxawU_hdn5TwFHLSdrrOK0t0AZIhGJWW2N3-_OGsg; Path=/; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -615,8 +615,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/logout HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDY3MTU2ODd9.e0dNbh70DSo0zKc8Gn43iKTJfFG4naeajuUDTrLbm1ZOXYF1v_KmJHaFHs6e0KGu9dcQJbPBgASS-8k5-2FGiQ
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA2NzEyMDg3LCJleHAiOjE3MDc5MjE2ODd9.t1kG7uZ3xIlWA9huJHzsXoHPIthkayuN05wPUaSsZFANyROLtuk5OizgaCb995Y4jEwp5JGZyVz-vikmniUvqg</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDY4MDI0ODh9.29z6WjUNBwshKyYl6xJjdPHip2ODWGP717yIvPajjgFjkBlfuUo7Dxb-s4qvZPNdDHyI9zEs2b2OPDRK8Pd52g
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA2Nzk4ODg4LCJleHAiOjE3MDgwMDg0ODh9.72MYHytYUALdCAp9ZOwpgUjAmyyBK1Ykh2nJ1rHh3dcbZZldawXPKeqcYOlPyd36RyA7DliYrVZx6KziD1spoQ</code></pre>
 </div>
 </div>
 </div>
@@ -645,8 +645,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/token HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo0LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDY3MTU2ODl9.PmrUC0QCTUM3m3FVwtyYlV3lsSsw9fT9Ub218tI7hyePRWuwPpVrzvBvI7v8134zqwfAiu6T_OhvSyvTHFjcMg
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzA2NzEyMDg5LCJleHAiOjE3MDc5MjE2ODl9.0Y1_ned1eFygzoAohZ43mzhiBs5frxOcg3DmMgOEuM40JhhaXWc5D2Pvo_AvbGrgvPdq5qYlDI9ibMLIlSjhxg</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo0LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDY4MDI0ODl9.bGftr-uQiW2vj1ibTiMBSQ3HxjVlbM_kTgZGpw0_gHZqiYBWKFPbU2bONbjl-iJjuALQlRW6n7t3x4Y3WVvWZg
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzA2Nzk4ODg5LCJleHAiOjE3MDgwMDg0ODl9.xZPbFC6qpQL6M4_xZ3Kg82UzY6XB3MXAcTVpPPNIw9no3d3JAyBhsDj2JCy4aT5EebRlY41_UlTraMuRdGCx-Q</code></pre>
 </div>
 </div>
 </div>
@@ -1956,7 +1956,7 @@ dailryPage
 Content-Disposition: form-data; name=dailryPageRequest; filename=dailryPageRequest
 Content-Type: application/json
 
-{"background":"무지","elements":[{"id":"asdf","type":"textBox","order":1,"position":{"x":100,"y":50},"size":{"width":200,"height":100},"rotation":"90deg","properties":{"backgroundColor":"#ffcc00","color":"#333333","fontSize":12,"text":"아 어지럽다.","fontWeight":"bold","font":"굴림"}},{"id":"123avxsdf","type":"drawing","order":3,"position":{"x":100,"y":50},"size":{"width":250,"height":150},"rotation":"60deg","properties":{"base64":"YXNjc2FzYXZmbnJ0bnJ0bnN0"}},{"id":"123a21233df","type":"sticker","order":5,"position":{"x":110,"y":50},"size":{"width":300,"height":150},"rotation":"45deg","properties":{"imageUrl":"https://trboard.game.onstove.com/Data/TR/20180111/13/636512725318200105.jpg"}}]}
+{"background":"무지","elements":[{"id":"asdf","type":"textBox","order":1,"position":{"x":100,"y":50},"size":{"width":200,"height":100},"rotation":"90deg","typeContent":{"backgroundColor":"#ffcc00","color":"#333333","fontSize":12,"text":"아 어지럽다.","fontWeight":"bold","font":"굴림"}},{"id":"123avxsdf","type":"drawing","order":3,"position":{"x":100,"y":50},"size":{"width":250,"height":150},"rotation":"60deg","typeContent":{"base64":"YXNjc2FzYXZmbnJ0bnJ0bnN0"}},{"id":"123a21233df","type":"sticker","order":5,"position":{"x":110,"y":50},"size":{"width":300,"height":150},"rotation":"45deg","typeContent":{"imageUrl":"https://trboard.game.onstove.com/Data/TR/20180111/13/636512725318200105.jpg"}}]}
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
@@ -2069,7 +2069,7 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock">element의 회전정보</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>elements[].properties</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>elements[].typeContent</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">해당 element 타입별 개별속성</p></td>
 </tr>
@@ -2101,7 +2101,7 @@ Content-Type: application/json;charset=UTF-8
       "height" : 100
     },
     "rotation" : "90deg",
-    "properties" : {
+    "typeContent" : {
       "backgroundColor" : "#ffcc00",
       "color" : "#333333",
       "fontSize" : 12,
@@ -2122,7 +2122,7 @@ Content-Type: application/json;charset=UTF-8
       "height" : 150
     },
     "rotation" : "60deg",
-    "properties" : {
+    "typeContent" : {
       "base64" : "YXNjc2FzYXZmbnJ0bnJ0bnN0"
     }
   }, {
@@ -2138,7 +2138,7 @@ Content-Type: application/json;charset=UTF-8
       "height" : 150
     },
     "rotation" : "45deg",
-    "properties" : {
+    "typeContent" : {
       "imageUrl" : "https://trboard.game.onstove.com/Data/TR/20180111/13/636512725318200105.jpg"
     }
   } ]
@@ -2240,7 +2240,7 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">element의 회전정보</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>elements[].properties</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>elements[].typeContent</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">해당 element 타입별 개별속성</p></td>
@@ -2303,7 +2303,7 @@ Content-Type: application/json;charset=UTF-8
       "height" : 100
     },
     "rotation" : "90deg",
-    "properties" : {
+    "typeContent" : {
       "backgroundColor" : "#ffcc00",
       "color" : "#333333",
       "fontSize" : 12,
@@ -2324,7 +2324,7 @@ Content-Type: application/json;charset=UTF-8
       "height" : 150
     },
     "rotation" : "60deg",
-    "properties" : {
+    "typeContent" : {
       "base64" : "YXNjc2FzYXZmbnJ0bnJ0bnN0"
     }
   }, {
@@ -2340,7 +2340,7 @@ Content-Type: application/json;charset=UTF-8
       "height" : 150
     },
     "rotation" : "45deg",
-    "properties" : {
+    "typeContent" : {
       "imageUrl" : "https://trboard.game.onstove.com/Data/TR/20180111/13/636512725318200105.jpg"
     }
   } ]
@@ -2442,7 +2442,7 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">element의 회전정보</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>elements[].properties</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>elements[].typeContent</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">해당 element 타입별 개별속성</p></td>
@@ -3783,7 +3783,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-31 17:36:19 +0900
+Last updated 2024-02-01 13:08:01 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
@@ -140,7 +140,7 @@ class DailryPageControllerTest {
                             fieldWithPath("elements[].size.width").type(NUMBER).description("element의 너비"),
                             fieldWithPath("elements[].size.height").type(NUMBER).description("element의 높이"),
                             fieldWithPath("elements[].rotation").type(STRING).description("element의 회전정보"),
-                            fieldWithPath("elements[].properties").type(OBJECT).description("해당 element 타입별 개별속성")
+                            fieldWithPath("elements[].typeContent").type(OBJECT).description("해당 element 타입별 개별속성")
                     ),
                     relaxedResponseFields(
                             fieldWithPath("dailryPageId").type(NUMBER).description("다일리 페이지 id"),
@@ -156,7 +156,7 @@ class DailryPageControllerTest {
                             fieldWithPath("elements[].size.width").type(NUMBER).description("element의 너비"),
                             fieldWithPath("elements[].size.height").type(NUMBER).description("element의 높이"),
                             fieldWithPath("elements[].rotation").type(STRING).description("element의 회전정보"),
-                            fieldWithPath("elements[].properties").type(OBJECT).description("해당 element 타입별 개별속성")
+                            fieldWithPath("elements[].typeContent").type(OBJECT).description("해당 element 타입별 개별속성")
                     )
             ));
         }
@@ -205,7 +205,7 @@ class DailryPageControllerTest {
                             fieldWithPath("elements[].size.width").type(NUMBER).description("element의 너비"),
                             fieldWithPath("elements[].size.height").type(NUMBER).description("element의 높이"),
                             fieldWithPath("elements[].rotation").type(STRING).description("element의 회전정보"),
-                            fieldWithPath("elements[].properties").type(OBJECT).description("해당 element 타입별 개별속성")
+                            fieldWithPath("elements[].typeContent").type(OBJECT).description("해당 element 타입별 개별속성")
                     )
             ));
         }

--- a/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
@@ -89,15 +89,15 @@ public class DailryPageFixture {
         첫번째_elementsDTO.setSize(new DailryPageUpdateDTO.ElementDTO.SizeDTO(200, 100));
         첫번째_elementsDTO.setRotation("90deg");
 
-        Map<String, Object> properties = new HashMap<>();
-        properties.put("font", "굴림");
-        properties.put("text", "아 어지럽다.");
-        properties.put("color", "#333333");
-        properties.put("fontSize", 12);
-        properties.put("fontWeight", "bold");
-        properties.put("backgroundColor", "#ffcc00");
+        Map<String, Object> typeContent = new HashMap<>();
+        typeContent.put("font", "굴림");
+        typeContent.put("text", "아 어지럽다.");
+        typeContent.put("color", "#333333");
+        typeContent.put("fontSize", 12);
+        typeContent.put("fontWeight", "bold");
+        typeContent.put("backgroundColor", "#ffcc00");
 
-        첫번째_elementsDTO.setProperties(properties);
+        첫번째_elementsDTO.setTypeContent(typeContent);
 
         return 첫번째_elementsDTO;
     }
@@ -111,10 +111,10 @@ public class DailryPageFixture {
         두번째_elementsDTO.setSize(new DailryPageUpdateDTO.ElementDTO.SizeDTO(250, 150));
         두번째_elementsDTO.setRotation("60deg");
 
-        Map<String, Object> properties = new HashMap<>();
-        properties.put("base64", "YXNjc2FzYXZmbnJ0bnJ0bnN0");
+        Map<String, Object> typeContent = new HashMap<>();
+        typeContent.put("base64", "YXNjc2FzYXZmbnJ0bnJ0bnN0");
 
-        두번째_elementsDTO.setProperties(properties);
+        두번째_elementsDTO.setTypeContent(typeContent);
 
         return 두번째_elementsDTO;
     }
@@ -128,10 +128,10 @@ public class DailryPageFixture {
         세번째_elementsDTO.setSize(new DailryPageUpdateDTO.ElementDTO.SizeDTO(300, 150));
         세번째_elementsDTO.setRotation("45deg");
 
-        Map<String, Object> properties = new HashMap<>();
-        properties.put("imageUrl", "https://trboard.game.onstove.com/Data/TR/20180111/13/636512725318200105.jpg");
+        Map<String, Object> typeContent = new HashMap<>();
+        typeContent.put("imageUrl", "https://trboard.game.onstove.com/Data/TR/20180111/13/636512725318200105.jpg");
 
-        세번째_elementsDTO.setProperties(properties);
+        세번째_elementsDTO.setTypeContent(typeContent);
 
         return 세번째_elementsDTO;
     }

--- a/backend/src/test/java/com/daily/daily/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/member/repository/MemberRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.daily.daily.member.repository;
 
+import com.daily.daily.common.config.QuerydslConfig;
 import com.daily.daily.member.constant.MemberRole;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.member.validator.Nickname;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Import(QuerydslConfig.class)
 class MemberRepositoryTest {
 
     static final String TEST_USERNAME = "geonwoo123";

--- a/backend/src/test/java/com/daily/daily/post/repository/PostLikeRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/post/repository/PostLikeRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.daily.daily.post.repository;
 
+import com.daily.daily.common.config.QuerydslConfig;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.domain.PostLike;
@@ -10,8 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@Import(QuerydslConfig.class)
 class PostLikeRepositoryTest {
 
     @Autowired

--- a/backend/src/test/java/com/daily/daily/postcomment/repository/PostCommentRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/postcomment/repository/PostCommentRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.daily.daily.postcomment.repository;
 
+import com.daily.daily.common.config.QuerydslConfig;
 import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.repository.PostRepository;
 import com.daily.daily.postcomment.domain.PostComment;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
@@ -15,6 +17,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@Import(QuerydslConfig.class)
 class PostCommentRepositoryTest {
 
     @Autowired PostCommentRepository commentRepository;


### PR DESCRIPTION
## 연관 이슈
close: #202 
## 작업 내용

- 게시글 조회시 N+1쿼리 해결
- submodule의 yml 파일 업데이트
   -  default_batch_fetch_size: 200 으로 설정했습니다. 
       -  JPA에서 일대다 관계에서 N+1문제를 해결하기 위해서 해당 설정(BatchSize)을 사용한다고 하네요
   -  jpa naming strategy를 업데이트 했습니다.
      - org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy 
      - 엔티티 네이밍에서 Camel 규칙에 해당하는 부분을 Underscore로 치환해줍니다.
      - ex) createdTime -> created_time
      - 로컬에서 테이블 한 번 다 날리고 작업하시는 것을 추천드립니다.

- Querydsl 의존성을 추가했습니다.
- p6spy 의존성을 추가했습니다.
   - sql에서 ? 로 뜨는 바인딩 파라미터를 실제 값으로 대체해줍니다.
   - 개발 단계에서 사용하기 좋은 것 같습니다. 실제 나가는 쿼리를 볼 수가 있습니다.
   - 운영 단계에서는 빼는 것이 좋아 보입니다. (성능문제)
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
