### PR TITLE
테스트 코드에서 @MockBean(JpaMetamodelMappingContext.class) 제거

### DIFF
--- a/backend/src/main/java/com/daily/daily/DaIlyApplication.java
+++ b/backend/src/main/java/com/daily/daily/DaIlyApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class DaIlyApplication {
     public static void main(String[] args) {

--- a/backend/src/main/java/com/daily/daily/common/config/JPAConfig.java
+++ b/backend/src/main/java/com/daily/daily/common/config/JPAConfig.java
@@ -1,0 +1,9 @@
+package com.daily.daily.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JPAConfig {
+}

--- a/backend/src/test/java/com/daily/daily/dailry/controller/DailryControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailry/controller/DailryControllerTest.java
@@ -40,7 +40,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
 })
-@MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 public class DailryControllerTest {
 

--- a/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
@@ -45,7 +45,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
 })
-@MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 class DailryPageControllerTest {
 

--- a/backend/src/test/java/com/daily/daily/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/member/controller/MemberControllerTest.java
@@ -46,7 +46,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
 })
-@MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 class MemberControllerTest {
 

--- a/backend/src/test/java/com/daily/daily/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/PostControllerTest.java
@@ -58,7 +58,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
 })
-@MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 class PostControllerTest {
 

--- a/backend/src/test/java/com/daily/daily/post/controller/PostLikeControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/PostLikeControllerTest.java
@@ -34,7 +34,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
 })
-@MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 class PostLikeControllerTest {
     @Autowired

--- a/backend/src/test/java/com/daily/daily/postcomment/controller/PostCommentControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/postcomment/controller/PostCommentControllerTest.java
@@ -59,7 +59,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
 })
-@MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 class PostCommentControllerTest {
 

--- a/backend/src/test/java/com/daily/daily/testutil/mockmvc/MockMvcTest.java
+++ b/backend/src/test/java/com/daily/daily/testutil/mockmvc/MockMvcTest.java
@@ -20,7 +20,6 @@ import org.springframework.test.web.servlet.MockMvc;
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
 })
-@MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 public class MockMvcTest {
 


### PR DESCRIPTION
## 연관 이슈
close: #208 

## 작업 내용
- `JPAConfig` 에서 `@EnableJpaAuditing` 설정하기. 
   - `@EnableJpaAuditing` 은 저희 프로젝트에서 `BaseTimeEntity` 와 관련된 설정
- 컨트롤러 테스트에서 `@MockBean(JpaMetamodelMappingContext.class)` 제거

## 의논할 거리
## Merge 전에 해야할 작업
## 기타

참고 자료
https://giron.tistory.com/127
