### PR TITLE
엔티티 클래스에서 @AllArgsConstructor 제거하기

### DIFF
--- a/backend/src/main/java/com/daily/daily/dailry/domain/Dailry.java
+++ b/backend/src/main/java/com/daily/daily/dailry/domain/Dailry.java
@@ -8,10 +8,7 @@ import lombok.*;
 import java.util.Objects;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
-@Builder
 public class Dailry extends BaseTimeEntity {
 
     @Id
@@ -22,6 +19,15 @@ public class Dailry extends BaseTimeEntity {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
+
+    protected Dailry() {
+    }
+
+    @Builder
+    public Dailry(String title, Member member) {
+        this.title = title;
+        this.member = member;
+    }
 
     public void updateTitle(String title) {
         this.title = title;

--- a/backend/src/main/java/com/daily/daily/dailrypage/domain/DailryPage.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/domain/DailryPage.java
@@ -4,8 +4,15 @@ import com.daily.daily.common.domain.BaseTimeEntity;
 import com.daily.daily.dailry.domain.Dailry;
 import com.daily.daily.dailrypage.dto.DailryPageUpdateDTO;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
 import org.hibernate.annotations.Type;
 
 import java.util.HashMap;
@@ -14,10 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
-@Builder
 public class DailryPage extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,6 +39,14 @@ public class DailryPage extends BaseTimeEntity {
     @JoinColumn(name = "dailry_id")
     private Dailry dailry;
 
+    @Builder
+    public DailryPage(Integer pageNumber, Dailry dailry) {
+        this.pageNumber = pageNumber;
+        this.dailry = dailry;
+    }
+    protected DailryPage() {
+    }
+
     public static DailryPage createEmptyPage() {
         return new DailryPage();
     }
@@ -43,7 +55,9 @@ public class DailryPage extends BaseTimeEntity {
         this.background = background;
     }
 
-    public void updatePageNumber(int pageNumber) { this.pageNumber = pageNumber; }
+    public void updatePageNumber(int pageNumber) {
+        this.pageNumber = pageNumber;
+    }
 
     public void updateElements(List<DailryPageUpdateDTO.ElementDTO> elements) {
         for (DailryPageUpdateDTO.ElementDTO element : elements) {

--- a/backend/src/main/java/com/daily/daily/member/domain/Member.java
+++ b/backend/src/main/java/com/daily/daily/member/domain/Member.java
@@ -9,9 +9,6 @@ import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 public class Member extends BaseTimeEntity {
 
     @Id
@@ -27,6 +24,19 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
 
+    @Builder
+    public Member(String username, String password, String nickname, String email, MemberRole role, String socialId, SocialType socialType) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+        this.email = email;
+        this.role = role;
+        this.socialId = socialId;
+        this.socialType = socialType;
+    }
+
+    protected Member() {
+    }
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;

--- a/backend/src/main/java/com/daily/daily/post/domain/Hashtag.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Hashtag.java
@@ -12,13 +12,14 @@ import lombok.ToString;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString
 public class Hashtag extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String tagName;
+
+    protected Hashtag() {
+    }
 
     public static Hashtag of(String tagName) {
         return new Hashtag(tagName);

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -12,11 +12,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Transient;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,9 +22,6 @@ import java.util.stream.Collectors;
 
 @Entity
 @Getter
-@AllArgsConstructor
-@Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseTimeEntity {
 
 
@@ -48,6 +42,15 @@ public class Post extends BaseTimeEntity {
     @Transient
     private Long likeCount;
 
+    @Builder
+    public Post(String content, String pageImage, Member postWriter) {
+        this.content = content;
+        this.pageImage = pageImage;
+        this.postWriter = postWriter;
+    }
+
+    protected Post() {
+    }
 
     public void updatePageImage(String pageImage) {
         this.pageImage = pageImage;

--- a/backend/src/main/java/com/daily/daily/post/domain/PostHashtag.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/PostHashtag.java
@@ -13,7 +13,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class PostHashtag extends BaseTimeEntity {
     @Id
@@ -32,6 +31,9 @@ public class PostHashtag extends BaseTimeEntity {
     private PostHashtag(Post post, Hashtag hashtag) {
         this.post = post;
         this.hashtag = hashtag;
+    }
+
+    protected PostHashtag() {
     }
 
     public static PostHashtag of(Post post, Hashtag hashtag) {

--- a/backend/src/main/java/com/daily/daily/post/domain/PostLike.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/PostLike.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostLike extends BaseTimeEntity {
 
     @Id
@@ -34,5 +33,8 @@ public class PostLike extends BaseTimeEntity {
     public PostLike(Post post, Member member) {
         this.post = post;
         this.member = member;
+    }
+
+    protected PostLike() {
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/domain/PostLike.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/PostLike.java
@@ -9,14 +9,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@AllArgsConstructor @Builder @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostLike extends BaseTimeEntity {
 
     @Id
@@ -30,4 +29,10 @@ public class PostLike extends BaseTimeEntity {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Builder
+    public PostLike(Post post, Member member) {
+        this.post = post;
+        this.member = member;
+    }
 }

--- a/backend/src/main/java/com/daily/daily/postcomment/domain/PostComment.java
+++ b/backend/src/main/java/com/daily/daily/postcomment/domain/PostComment.java
@@ -19,8 +19,7 @@ import lombok.ToString;
 
 @Entity
 @Getter
-@AllArgsConstructor @Builder @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostComment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,6 +34,13 @@ public class PostComment extends BaseTimeEntity {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member commentWriter;
+
+    @Builder
+    public PostComment(String content, Post post, Member commentWriter) {
+        this.content = content;
+        this.post = post;
+        this.commentWriter = commentWriter;
+    }
 
     public Long getPostId() {
         return post.getId();

--- a/backend/src/main/java/com/daily/daily/postcomment/domain/PostComment.java
+++ b/backend/src/main/java/com/daily/daily/postcomment/domain/PostComment.java
@@ -19,7 +19,6 @@ import lombok.ToString;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostComment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,6 +39,9 @@ public class PostComment extends BaseTimeEntity {
         this.content = content;
         this.post = post;
         this.commentWriter = commentWriter;
+    }
+
+    protected PostComment() {
     }
 
     public Long getPostId() {

--- a/backend/src/main/java/com/daily/daily/postcomment/service/PostCommentService.java
+++ b/backend/src/main/java/com/daily/daily/postcomment/service/PostCommentService.java
@@ -49,7 +49,7 @@ public class PostCommentService {
 
         validateAuthorityToComment(findComment, writerId);
 
-        if (writerId.longValue() != findComment.getWriterId().longValue()) {
+        if (!findComment.isWrittenBy(writerId)) {
             throw new UnauthorizedAccessException();
         }
 

--- a/backend/src/test/java/com/daily/daily/dailry/fixture/DailryFixture.java
+++ b/backend/src/test/java/com/daily/daily/dailry/fixture/DailryFixture.java
@@ -4,6 +4,7 @@ import com.daily.daily.dailry.domain.Dailry;
 import com.daily.daily.dailry.dto.DailryDTO;
 import com.daily.daily.dailry.dto.DailryFindDTO;
 import com.daily.daily.dailry.dto.DailryUpdateDTO;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,19 +63,23 @@ public class DailryFixture {
     }
 
     public static Dailry 일반회원1이_작성한_다일리() {
-        return Dailry.builder()
-                .id(DAILRY_ID)
+        Dailry 다일리 = Dailry.builder()
                 .title(다일리_제목)
                 .member(일반회원1())
                 .build();
+
+        ReflectionTestUtils.setField(다일리, "id", DAILRY_ID);
+        return 다일리;
     }
 
     public static Dailry 일반회원1이_작성한_2번째_다일리() {
-        return Dailry.builder()
-                .id(DAILRY_ID_2)
+        Dailry 다일리 = Dailry.builder()
                 .title(다일리_제목)
                 .member(일반회원1())
                 .build();
+
+        ReflectionTestUtils.setField(다일리, "id", DAILRY_ID);
+        return 다일리;
     }
 
 }

--- a/backend/src/test/java/com/daily/daily/member/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/daily/daily/member/fixture/MemberFixture.java
@@ -3,6 +3,7 @@ package com.daily.daily.member.fixture;
 import com.daily.daily.member.constant.MemberRole;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.oauth.constant.SocialType;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class MemberFixture {
 
@@ -22,36 +23,42 @@ public class MemberFixture {
     private static String 구글소셜회원_이메일 = "googlesocial@gmail.com";
 
     public static Member 일반회원1() {
-        return Member.builder()
-                .id(일반회원1_ID)
+        Member 일반회원1 = Member.builder()
                 .username(일반회원1_유저네임)
                 .nickname(일반회원1_닉네임)
                 .email(일반회원1_이메일)
                 .socialType(SocialType.NONE)
                 .role(MemberRole.ROLE_MEMBER)
                 .build();
+
+        ReflectionTestUtils.setField(일반회원1, "id", 일반회원1_ID);
+        return 일반회원1;
     }
 
     public static Member 일반회원2() {
-        return Member.builder()
-                .id(일반회원2_ID)
+        Member 일반회원2 = Member.builder()
                 .username(일반회원2_유저네임)
                 .nickname(일반회원2_닉네임)
                 .email(일반회원2_이메일)
                 .socialType(SocialType.NONE)
                 .role(MemberRole.ROLE_MEMBER)
                 .build();
+
+        ReflectionTestUtils.setField(일반회원2, "id", 일반회원2_ID);
+        return 일반회원2;
     }
 
 
     public static Member 구글소셜회원() {
-        return Member.builder()
-                .id(구글소셜회원_ID)
+        Member 구글소셜회원 = Member.builder()
                 .username(구글소셜회원_유저네임)
                 .nickname(구글소셜회원_닉네임)
                 .email(구글소셜회원_이메일)
                 .socialType(SocialType.GOOGLE)
                 .role(MemberRole.ROLE_MEMBER)
                 .build();
+
+        ReflectionTestUtils.setField(구글소셜회원, "id", 구글소셜회원_ID);
+        return 구글소셜회원;
     }
 }

--- a/backend/src/test/java/com/daily/daily/member/service/MemberEmailServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/member/service/MemberEmailServiceTest.java
@@ -83,7 +83,6 @@ class MemberEmailServiceTest {
 
         //when
         Member mockMember = Member.builder()
-                .id(1L)
                 .socialType(SocialType.NONE)
                 .build();
 
@@ -102,7 +101,6 @@ class MemberEmailServiceTest {
 
         //when
         Member mockMember = Member.builder()
-                .id(1L)
                 .socialType(SocialType.GOOGLE)
                 .build();
 
@@ -122,7 +120,6 @@ class MemberEmailServiceTest {
 
         //when
         Member mockMember = Member.builder()
-                .id(1L)
                 .email("test@example.com")
                 .username("test")
                 .socialType(SocialType.NONE)
@@ -144,7 +141,6 @@ class MemberEmailServiceTest {
 
         //when
         Member mockMember = Member.builder()
-                .id(1L)
                 .email("test@example.com")
                 .username("test123")  // 이메일과 매칭되는 username 정보가 다를 때
                 .build();

--- a/backend/src/test/java/com/daily/daily/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/member/service/MemberServiceTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -82,13 +83,12 @@ class MemberServiceTest {
     void updateNickname() {
         //given
         Member member = Member.builder()
-                .id(1L)
                 .username("username1")
                 .nickname("임시닉네임")
                 .build();
 
         when(memberRepository.existsByNickname("바꾸고 싶은 닉네임")).thenReturn(true);
-        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
 
         //when, then
         assertThatThrownBy(() -> memberService.updateNickname(1L, "바꾸고 싶은 닉네임"))
@@ -124,7 +124,6 @@ class MemberServiceTest {
 
     private Member createTestMember(String password) {
         return Member.builder()
-                .id(1L)
                 .username("username1")
                 .nickname("nickname")
                 .password(new BCryptPasswordEncoder().encode(password))

--- a/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
+++ b/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
@@ -9,6 +9,7 @@ import com.daily.daily.post.dto.PostReadSliceResponseDTO;
 import com.daily.daily.post.dto.PostWriteRequestDTO;
 import com.daily.daily.post.dto.PostWriteResponseDTO;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -151,14 +152,13 @@ public class PostFixture {
 
     public static Post 일반회원1이_작성한_게시글() {
         Post post = Post.builder()
-                .id(3L)
                 .content(POST_CONTENT)
                 .pageImage(PAGE_IMAGE_URL)
                 .postWriter(일반회원1())
                 .build();
 
         HASHTAGS.forEach(hashtag -> post.addPostHashtag(PostHashtag.of(post, hashtag)));
-
+        ReflectionTestUtils.setField(post, "id", POST_ID);
         return post;
     }
 }

--- a/backend/src/test/java/com/daily/daily/postcomment/fixture/PostCommentFixture.java
+++ b/backend/src/test/java/com/daily/daily/postcomment/fixture/PostCommentFixture.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -34,10 +35,16 @@ public class PostCommentFixture {
     }
 
     public static PostCommentResponseDTO 댓글_응답_DTO() {
-        PostCommentResponseDTO result = PostCommentResponseDTO.from(일반회원2가_작성한_댓글_to_일반회원1이_작성한_게시글());
-        result.setCreatedTime(댓글_생성_시간);
+        PostCommentResponseDTO 댓글_응답_DTO = PostCommentResponseDTO.builder()
+                .commentId(COMMENT_ID)
+                .postId(4L)
+                .writerId(10L)
+                .writerNickname("gomudayya")
+                .content("오오 멋있어요")
+                .createdTime(댓글_생성_시간)
+                .build();
 
-        return result;
+        return 댓글_응답_DTO;
     }
 
     public static PostCommentResponseDTO 수정된_댓글_응답_DTO() {
@@ -48,21 +55,48 @@ public class PostCommentFixture {
     }
 
     public static PostCommentSliceDTO 댓글_조회_페이징_DTO() {
-        PostCommentSliceDTO result = PostCommentSliceDTO.from(댓글_페이징_결과());
+        PostCommentSliceDTO.SingleCommentDTO 첫번째_댓글 = PostCommentSliceDTO.SingleCommentDTO.builder()
+                .commentId(2L)
+                .createdTime(댓글_생성_시간)
+                .content("와우")
+                .writerNickname("뚱냥이")
+                .build();
 
-        result.getComments()
-                .forEach(commentDTO -> commentDTO.setCreatedTime(댓글_생성_시간)); //생성시간 설정
+        PostCommentSliceDTO.SingleCommentDTO 두번째_댓글 = PostCommentSliceDTO.SingleCommentDTO.builder()
+                .commentId(5L)
+                .createdTime(댓글_생성_시간)
+                .content("허걱")
+                .writerNickname("돼냥이")
+                .build();
 
-        return result;
+        PostCommentSliceDTO.SingleCommentDTO 세번째_댓글 = PostCommentSliceDTO.SingleCommentDTO.builder()
+                .commentId(16L)
+                .createdTime(댓글_생성_시간)
+                .content("오오 멋있어요")
+                .writerNickname("gomudayya")
+                .build();
+
+        PostCommentSliceDTO 댓글_조회_페이징_DTO = PostCommentSliceDTO.builder()
+                .hasNext(true)
+                .presentPage(요청_페이지_숫자)
+                .comments(List.of(첫번째_댓글, 두번째_댓글, 세번째_댓글))
+                .build();
+
+        return 댓글_조회_페이징_DTO;
     }
 
     public static PostComment 일반회원2가_작성한_댓글_to_일반회원1이_작성한_게시글() {
-        return PostComment.builder()
-                .id(COMMENT_ID)
+        PostComment build = PostComment.builder()
+//                .id(COMMENT_ID)
                 .content(댓글_내용)
                 .post(일반회원1이_작성한_게시글())
                 .commentWriter(일반회원2())
                 .build();
+
+        ReflectionTestUtils.setField(build, "id", COMMENT_ID);
+        return build;
+
+
     }
 
     public static Pageable 댓글_페이징_요청_객체() {
@@ -83,7 +117,7 @@ public class PostCommentFixture {
     }
     private static PostComment 일반회원2가_작성한_댓글_to_일반회원1이_작성한_게시글(Long id, String content) {
         return PostComment.builder()
-                .id(id)
+//                .id(id)
                 .content(content)
                 .post(일반회원1이_작성한_게시글())
                 .commentWriter(일반회원2())

--- a/backend/src/test/java/com/daily/daily/postcomment/fixture/PostCommentFixture.java
+++ b/backend/src/test/java/com/daily/daily/postcomment/fixture/PostCommentFixture.java
@@ -86,17 +86,14 @@ public class PostCommentFixture {
     }
 
     public static PostComment 일반회원2가_작성한_댓글_to_일반회원1이_작성한_게시글() {
-        PostComment build = PostComment.builder()
-//                .id(COMMENT_ID)
+        PostComment 댓글 = PostComment.builder()
                 .content(댓글_내용)
                 .post(일반회원1이_작성한_게시글())
                 .commentWriter(일반회원2())
                 .build();
 
-        ReflectionTestUtils.setField(build, "id", COMMENT_ID);
-        return build;
-
-
+        ReflectionTestUtils.setField(댓글, "id", COMMENT_ID);
+        return 댓글;
     }
 
     public static Pageable 댓글_페이징_요청_객체() {
@@ -110,11 +107,12 @@ public class PostCommentFixture {
         long end = start + 요청_페이지_사이즈;
 
         for (long i = start; i < end; i++) {
-            result.add(일반회원2가_작성한_댓글_to_일반회원1이_작성한_게시글(i+5* i, i + "번째 댓글입니다."));
+            result.add(일반회원2가_작성한_댓글_to_일반회원1이_작성한_게시글(i + 5 * i, i + "번째 댓글입니다."));
         }
 
         return new SliceImpl<>(result, 댓글_페이징_요청_객체(), true);
     }
+
     private static PostComment 일반회원2가_작성한_댓글_to_일반회원1이_작성한_게시글(Long id, String content) {
         return PostComment.builder()
 //                .id(id)

--- a/backend/src/test/java/com/daily/daily/postcomment/service/PostCommentServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/postcomment/service/PostCommentServiceTest.java
@@ -79,19 +79,19 @@ class PostCommentServiceTest {
         @DisplayName("파라미터에 들어온 값들을 토대로 댓글을 수정해야 한다.")
         void test1() {
             //given
-            Member 댓글_수정_요청자 = 일반회원2();
             PostComment 댓글 = 일반회원2가_작성한_댓글_to_일반회원1이_작성한_게시글();
             PostCommentRequestDTO 댓글_요청_DTO = 댓글_수정_DTO();
 
-            when(commentRepository.findById(any(Long.class))).thenReturn(Optional.of(댓글));
+            when(commentRepository.findById(any())).thenReturn(Optional.of(댓글));
 
             //when
-            PostCommentResponseDTO 결과 = commentService.update(댓글_수정_요청자.getId(), 댓글.getId(), 댓글_요청_DTO);
+            PostCommentResponseDTO 결과 = commentService.update(댓글.getWriterId(), 댓글.getId(), 댓글_요청_DTO);
 
             //then
+            assertThat(결과.getWriterNickname()).isEqualTo(댓글.getWriterNickname());
             assertThat(결과.getCommentId()).isEqualTo(댓글.getId());
             assertThat(결과.getContent()).isEqualTo(댓글_요청_DTO.getContent());
-            assertThat(결과.getWriterId()).isEqualTo(댓글_수정_요청자.getId());
+            assertThat(결과.getWriterId()).isEqualTo(댓글.getWriterId());
         }
 
         @Test


### PR DESCRIPTION
## 연관 이슈
close: #210 
## 작업 내용

- 엔티티 클래스에서 `@AllArgsConstructor`를 제거하였습니다.
   - 이제 엔티티를 생성할 때 `id`값을 할당할 수 없습니다.
- `@AllArgsConstructor`를 제거하니 `id`를 활용한 테스트 코드에서 문제가 생겼습니다.
   - 찾아보니 스프링 테스트 유틸 중에 `ReflectionTestUtils` 를 사용하면 private 필드에도 접근해서 값을 부여할 수가 있었습니다.
   - ex : `ReflectionTestUtils.setField(댓글, "id", COMMENT_ID);` 
   - 그래서 해당 유틸 클래스를 사용해서 테스트 픽스쳐의 id값을 할당했습니다.
- 엔티티 클래스에서 `@NoArgsConstructor(Access = 'protected')` 어노테이션을 제거하였습니다.
   - 어노테이션이 너무 많이붙어있는게 지저분하기도 했고
   - 자바 코드로도 한 줄로 축약이 되어서, 롬복 어노테이션에 의존하기 보다는 그냥 자바 코드로 protected 생성자를 만들어 주는 것이 낫다고 판단하였습니다.
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
