### PR TITLE
다일리 페이지 관련 리팩토링

### DIFF
--- a/backend/src/main/java/com/daily/daily/dailrypage/controller/DailryPageController.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/controller/DailryPageController.java
@@ -26,13 +26,6 @@ public class DailryPageController {
 
     private final DailryPageService dailryPageService;
 
-    @PostMapping("/api/pages")
-    @Secured(value = "ROLE_MEMBER")
-    @ResponseStatus(HttpStatus.CREATED)
-    public DailryPageCreateResponseDTO createPage() {
-        return dailryPageService.create();
-    }
-
     @PostMapping("/api/dailry/{dailryID}/pages")
     @Secured(value = "ROLE_MEMBER")
     @ResponseStatus(HttpStatus.CREATED)

--- a/backend/src/main/java/com/daily/daily/dailrypage/controller/DailryPageController.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/controller/DailryPageController.java
@@ -4,7 +4,6 @@ import com.daily.daily.common.dto.SuccessResponseDTO;
 import com.daily.daily.dailrypage.dto.DailryPageCreateResponseDTO;
 import com.daily.daily.dailrypage.dto.DailryPageDTO;
 import com.daily.daily.dailrypage.dto.DailryPagePreviewDTO;
-import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
 import com.daily.daily.dailrypage.dto.DailryPageUpdateDTO;
 import com.daily.daily.dailrypage.service.DailryPageService;
 import jakarta.validation.Valid;
@@ -16,8 +15,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/dailry")
@@ -28,8 +25,8 @@ public class DailryPageController {
     @PostMapping("/{dailryID}/pages")
     @Secured(value = "ROLE_MEMBER")
     @ResponseStatus(HttpStatus.CREATED)
-    public DailryPageCreateResponseDTO createPage2(@AuthenticationPrincipal Long memberId, @PathVariable Long dailryID) {
-        return dailryPageService.create2(memberId, dailryID);
+    public DailryPageCreateResponseDTO createPage(@AuthenticationPrincipal Long memberId, @PathVariable Long dailryID) {
+        return dailryPageService.create(memberId, dailryID);
     }
 
     @PostMapping("/pages/{pageId}/edit")

--- a/backend/src/main/java/com/daily/daily/dailrypage/controller/DailryPageController.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/controller/DailryPageController.java
@@ -20,20 +20,19 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-//@RequestMapping("/api/dailry/{dailryID}/pages")
-//@RequestMapping("/api/pages")
+@RequestMapping("/api/dailry")
 public class DailryPageController {
 
     private final DailryPageService dailryPageService;
 
-    @PostMapping("/api/dailry/{dailryID}/pages")
+    @PostMapping("/{dailryID}/pages")
     @Secured(value = "ROLE_MEMBER")
     @ResponseStatus(HttpStatus.CREATED)
     public DailryPageCreateResponseDTO createPage2(@AuthenticationPrincipal Long memberId, @PathVariable Long dailryID) {
         return dailryPageService.create2(memberId, dailryID);
     }
 
-    @PostMapping("/api/dailry/pages/{pageId}/edit")
+    @PostMapping("/pages/{pageId}/edit")
     @Secured(value = "ROLE_MEMBER")
     public DailryPageDTO updatePage(
             @AuthenticationPrincipal Long memberId,
@@ -43,19 +42,19 @@ public class DailryPageController {
         return dailryPageService.update(memberId, pageId, dailryPageRequest, thumbnail);
     }
 
-    @GetMapping("/api/dailry/pages/{pageId}")
+    @GetMapping("/pages/{pageId}")
     @Secured(value = "ROLE_MEMBER")
     public DailryPageDTO findPage(@AuthenticationPrincipal Long memberId, @PathVariable Long pageId) {
         return dailryPageService.find(memberId, pageId);
     }
 
-    @GetMapping("/api/dailry/{dailryId}/pages")
+    @GetMapping("/{dailryId}/pages")
     @Secured(value = "ROLE_MEMBER")
     public DailryPagePreviewDTO findAllPage(@AuthenticationPrincipal Long memberId, @PathVariable Long dailryId) {
         return dailryPageService.findAll(memberId, dailryId);
     }
 
-    @DeleteMapping("/api/dailry/pages/{pageId}")
+    @DeleteMapping("/pages/{pageId}")
     @Secured(value = "ROLE_MEMBER")
     public SuccessResponseDTO deletePage(@AuthenticationPrincipal Long memberId, @PathVariable Long pageId) {
         dailryPageService.delete(memberId, pageId);

--- a/backend/src/main/java/com/daily/daily/dailrypage/controller/DailryPageController.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/controller/DailryPageController.java
@@ -29,7 +29,7 @@ public class DailryPageController {
     @PostMapping("/api/dailry/{dailryID}/pages")
     @Secured(value = "ROLE_MEMBER")
     @ResponseStatus(HttpStatus.CREATED)
-    public DailryPageDTO createPage2(@AuthenticationPrincipal Long memberId, @PathVariable Long dailryID) {
+    public DailryPageCreateResponseDTO createPage2(@AuthenticationPrincipal Long memberId, @PathVariable Long dailryID) {
         return dailryPageService.create2(memberId, dailryID);
     }
 

--- a/backend/src/main/java/com/daily/daily/dailrypage/domain/DailryPage.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/domain/DailryPage.java
@@ -58,4 +58,8 @@ public class DailryPage extends BaseTimeEntity {
     public boolean belongsTo(Long memberId) {
         return Objects.equals(this.dailry.getMember().getId(), memberId);
     }
+
+    public Long getDailryId() {
+        return dailry.getId();
+    }
 }

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageCreateResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageCreateResponseDTO.java
@@ -9,12 +9,12 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class DailryPageCreateResponseDTO {
-    private Long dailryPageId;
+    private Long pageId;
     private String background;
     private Long pageNumber;
     public static DailryPageCreateResponseDTO from(DailryPage dailryPage) {
         return DailryPageCreateResponseDTO.builder()
-                .dailryPageId(dailryPage.getId())
+                .pageId(dailryPage.getId())
                 .background(dailryPage.getBackground())
                 .build();
     }

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageCreateResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageCreateResponseDTO.java
@@ -9,11 +9,13 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class DailryPageCreateResponseDTO {
+    private Long dailryId;
     private Long pageId;
     private String background;
     private Long pageNumber;
     public static DailryPageCreateResponseDTO from(DailryPage dailryPage) {
         return DailryPageCreateResponseDTO.builder()
+                .dailryId(dailryPage.getDailry().getId())
                 .pageId(dailryPage.getId())
                 .background(dailryPage.getBackground())
                 .build();

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageDTO.java
@@ -1,13 +1,10 @@
 package com.daily.daily.dailrypage.dto;
 
-import com.daily.daily.dailry.domain.Dailry;
 import com.daily.daily.dailrypage.domain.DailryPage;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.Collection;
 
 
 @Getter
@@ -15,7 +12,7 @@ import java.util.Collection;
 @AllArgsConstructor
 @Builder
 public class DailryPageDTO {
-    private Long dailryPageId;
+    private Long pageId;
     private String background;
     private String thumbnail;
     private int pageNumber;
@@ -23,7 +20,7 @@ public class DailryPageDTO {
 
     public static DailryPageDTO from(DailryPage dailryPage) {
         return DailryPageDTO.builder()
-                .dailryPageId(dailryPage.getId())
+                .pageId(dailryPage.getId())
                 .background(dailryPage.getBackground())
                 .thumbnail(dailryPage.getThumbnail())
                 .pageNumber(dailryPage.getPageNumber())

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageThumbnailDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageThumbnailDTO.java
@@ -8,8 +8,11 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class DailryPageThumbnailDTO {
-    private Integer pageId;
+    private Long pageId;
     private Integer pageNumber;
     private String thumbnail;
+
+    public DailryPageThumbnailDTO() {
+    }
 }
 

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageThumbnailDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageThumbnailDTO.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class DailryPageThumbnailDTO {
-    //TODO: pageId 추가 필요
     private Integer pageId;
     private Integer pageNumber;
     private String thumbnail;

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageThumbnailDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageThumbnailDTO.java
@@ -8,6 +8,8 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class DailryPageThumbnailDTO {
+    //TODO: pageId 추가 필요
+    private Integer pageId;
     private int pageNumber;
     private String thumbnail;
 }

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageThumbnailDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageThumbnailDTO.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 public class DailryPageThumbnailDTO {
     //TODO: pageId 추가 필요
     private Integer pageId;
-    private int pageNumber;
+    private Integer pageNumber;
     private String thumbnail;
 }
 

--- a/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageQuerydsl.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageQuerydsl.java
@@ -1,0 +1,10 @@
+package com.daily.daily.dailrypage.repository;
+
+import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
+
+import java.util.List;
+
+public interface DailryPageQuerydsl {
+    List<DailryPageThumbnailDTO> findThumbnails(Long dailryId);
+
+}

--- a/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageQuerydslImpl.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageQuerydslImpl.java
@@ -1,0 +1,29 @@
+package com.daily.daily.dailrypage.repository;
+
+import com.daily.daily.dailrypage.domain.QDailryPage;
+import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.daily.daily.dailrypage.domain.QDailryPage.dailryPage;
+
+@Repository
+@RequiredArgsConstructor
+public class DailryPageQuerydslImpl implements DailryPageQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<DailryPageThumbnailDTO> findThumbnails(Long dailryId) {
+        return queryFactory.select(Projections.bean(DailryPageThumbnailDTO.class,
+                        dailryPage.id.as("pageId"),
+                        dailryPage.pageNumber,
+                        dailryPage.thumbnail))
+                .from(dailryPage)
+                .fetch();
+    }
+}

--- a/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageRepository.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageRepository.java
@@ -4,10 +4,13 @@ import com.daily.daily.dailry.domain.Dailry;
 import com.daily.daily.dailrypage.domain.DailryPage;
 import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface DailryPageRepository extends JpaRepository<DailryPage, Long> {
     int countByDailry(Dailry dailry);
-    List<DailryPageThumbnailDTO> findPageNumbersAndThumbnailsByDailryId(Long dailryId);
+
+    @Query("select dp.id as pageId, dp.pageNumber, dp.thumbnail from DailryPage dp where dp.dailry.id = :dailryId")
+    List<DailryPageThumbnailDTO> findThumbnail(Long dailryId);
 }

--- a/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageRepository.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageRepository.java
@@ -8,9 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface DailryPageRepository extends JpaRepository<DailryPage, Long> {
+public interface DailryPageRepository extends JpaRepository<DailryPage, Long>, DailryPageQuerydsl {
     int countByDailry(Dailry dailry);
-
-    @Query("select dp.id as pageId, dp.pageNumber, dp.thumbnail from DailryPage dp where dp.dailry.id = :dailryId")
-    List<DailryPageThumbnailDTO> findThumbnail(Long dailryId);
 }

--- a/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
@@ -31,7 +31,7 @@ public class DailryPageService {
 
     private final S3StorageService storageService;
 
-    public DailryPageDTO create2(Long memberId, Long dailryId) {
+    public DailryPageCreateResponseDTO create2(Long memberId, Long dailryId) {
         Dailry dailry = dailryRepository.findById(dailryId)
                 .orElseThrow(DailryPageNotFoundException::new);
 
@@ -49,7 +49,7 @@ public class DailryPageService {
 
         DailryPage savedPage = dailryPageRepository.save(dailryPage);
 
-        return DailryPageDTO.from(savedPage);
+        return DailryPageCreateResponseDTO.from(savedPage);
     }
 
     public DailryPageDTO update(Long memberId, Long pageId, DailryPageUpdateDTO dailryPageUpdateDTO, MultipartFile thumbnail) {

--- a/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
@@ -96,7 +96,7 @@ public class DailryPageService {
             throw new UnauthorizedAccessException();
         }
 
-        List<DailryPageThumbnailDTO> thumbnails = dailryPageRepository.findPageNumbersAndThumbnailsByDailryId(dailryId);
+        List<DailryPageThumbnailDTO> thumbnails = dailryPageRepository.findThumbnail(dailryId);
 
         return DailryPagePreviewDTO.from(dailryId, thumbnails);
     }

--- a/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
@@ -31,7 +31,7 @@ public class DailryPageService {
 
     private final S3StorageService storageService;
 
-    public DailryPageCreateResponseDTO create2(Long memberId, Long dailryId) {
+    public DailryPageCreateResponseDTO create(Long memberId, Long dailryId) {
         Dailry dailry = dailryRepository.findById(dailryId)
                 .orElseThrow(DailryPageNotFoundException::new);
 

--- a/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
@@ -96,7 +96,7 @@ public class DailryPageService {
             throw new UnauthorizedAccessException();
         }
 
-        List<DailryPageThumbnailDTO> thumbnails = dailryPageRepository.findThumbnail(dailryId);
+        List<DailryPageThumbnailDTO> thumbnails = dailryPageRepository.findThumbnails(dailryId);
 
         return DailryPagePreviewDTO.from(dailryId, thumbnails);
     }

--- a/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
@@ -31,13 +31,6 @@ public class DailryPageService {
 
     private final S3StorageService storageService;
 
-
-    public DailryPageCreateResponseDTO create() {
-        DailryPage savedPage = dailryPageRepository.save(DailryPage.createEmptyPage());
-
-        return DailryPageCreateResponseDTO.from(savedPage);
-    }
-
     public DailryPageDTO create2(Long memberId, Long dailryId) {
         Dailry dailry = dailryRepository.findById(dailryId)
                 .orElseThrow(DailryPageNotFoundException::new);

--- a/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
@@ -33,7 +33,7 @@ public class DailryPageService {
 
     public DailryPageCreateResponseDTO create(Long memberId, Long dailryId) {
         Dailry dailry = dailryRepository.findById(dailryId)
-                .orElseThrow(DailryPageNotFoundException::new);
+                .orElseThrow(DailryNotFoundException::new);
 
         if (!dailry.belongsTo(memberId)) {
             throw new UnauthorizedAccessException();

--- a/backend/src/main/java/com/daily/daily/post/controller/PostController.java
+++ b/backend/src/main/java/com/daily/daily/post/controller/PostController.java
@@ -27,9 +27,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
-
-//TODO: 게시글 수정과 삭제는, 요청을 보낸사람의 신원을 확인해야 한다.
-// 자신이 작성한 게시글에 한해서, 수정과 삭제를 요청할 수 있다.
 public class PostController {
 
     private final PostService postService;

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -550,8 +550,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA2ODAyNDkwfQ.7HhXhKULTZYOwl4cqoRl5ObyBHe--f6OFZ-Zum_5ph8xL9ITTDygrdkQbri_KQGJ0tysBVqg2mxeJskv6dB66Q
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwNjc5ODg5MCwiZXhwIjoxNzA4MDA4NDkwfQ.zvQGmJENJv1pQNd8ehnWanozgP_xlGtx16iAK8LgMEPtXuxawU_hdn5TwFHLSdrrOK0t0AZIhGJWW2N3-_OGsg
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA3MjIxNDM2fQ.lnoFidYF2Hw2xvRR4IBwAXpQKSgRXMJ2iBa543FjeUGFvWQRpFHmR65YR2BEi84KxOoKAnB3B_FQThVu7VCDHQ
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwNzIxNzgzNiwiZXhwIjoxNzA4NDI3NDM2fQ.V_BioMeIc08rBmac7LCCSC-k07z_PHSWIP55jUK8nA0lKOOXODGcDsKpK6WoCWJvVMYxhpNMLTW39V4rMzywSA
 
 {
   "username" : "testtest",
@@ -595,8 +595,8 @@ Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwNjc5OD
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA2ODAyNDkwfQ.7HhXhKULTZYOwl4cqoRl5ObyBHe--f6OFZ-Zum_5ph8xL9ITTDygrdkQbri_KQGJ0tysBVqg2mxeJskv6dB66Q; Path=/; Secure; HttpOnly; SameSite=None
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwNjc5ODg5MCwiZXhwIjoxNzA4MDA4NDkwfQ.zvQGmJENJv1pQNd8ehnWanozgP_xlGtx16iAK8LgMEPtXuxawU_hdn5TwFHLSdrrOK0t0AZIhGJWW2N3-_OGsg; Path=/; Secure; HttpOnly; SameSite=None
+Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA3MjIxNDM2fQ.lnoFidYF2Hw2xvRR4IBwAXpQKSgRXMJ2iBa543FjeUGFvWQRpFHmR65YR2BEi84KxOoKAnB3B_FQThVu7VCDHQ; Path=/; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwNzIxNzgzNiwiZXhwIjoxNzA4NDI3NDM2fQ.V_BioMeIc08rBmac7LCCSC-k07z_PHSWIP55jUK8nA0lKOOXODGcDsKpK6WoCWJvVMYxhpNMLTW39V4rMzywSA; Path=/; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -615,8 +615,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/logout HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDY4MDI0ODh9.29z6WjUNBwshKyYl6xJjdPHip2ODWGP717yIvPajjgFjkBlfuUo7Dxb-s4qvZPNdDHyI9zEs2b2OPDRK8Pd52g
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA2Nzk4ODg4LCJleHAiOjE3MDgwMDg0ODh9.72MYHytYUALdCAp9ZOwpgUjAmyyBK1Ykh2nJ1rHh3dcbZZldawXPKeqcYOlPyd36RyA7DliYrVZx6KziD1spoQ</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDcyMjE0MzR9.sCeiwPes6N5U97NQVCSQp5L80cJ-mdoaZ2mJQVT3u1dSAStjACXMH1mrUAveoICoFcpoaINaX7O0MFIPxTdYAg
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA3MjE3ODM0LCJleHAiOjE3MDg0Mjc0MzR9.V_sSX3olnZZUm19oY-t2XyuOWD9swgYwKu9rd_8xRoreE5CB7c6ywqXCK10STdMHrXHo8Ej8G_dAvhFR_-AXRg</code></pre>
 </div>
 </div>
 </div>
@@ -645,8 +645,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/token HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo0LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDY4MDI0ODl9.bGftr-uQiW2vj1ibTiMBSQ3HxjVlbM_kTgZGpw0_gHZqiYBWKFPbU2bONbjl-iJjuALQlRW6n7t3x4Y3WVvWZg
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzA2Nzk4ODg5LCJleHAiOjE3MDgwMDg0ODl9.xZPbFC6qpQL6M4_xZ3Kg82UzY6XB3MXAcTVpPPNIw9no3d3JAyBhsDj2JCy4aT5EebRlY41_UlTraMuRdGCx-Q</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo0LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDcyMjE0MzV9.K6Gn1PwOq4Kjo1sR33BHFGl9hVkdFmOu84TfvqA2TmWwTIIlU3dZK-_mQePx2a9fwUifjjdh9yodRbchMFQ2xg
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzA3MjE3ODM1LCJleHAiOjE3MDg0Mjc0MzV9.g_9wmqeEIGW_ExP9hDd4z5pBmSzFNzyEPhaTJixtxZ_c_Tqb2zIXVEKMpcxEygm0jVsdZaNGHxiPbTm1H7NdFg</code></pre>
 </div>
 </div>
 </div>
@@ -1794,7 +1794,7 @@ Content-Type: application/json;charset=UTF-8
   "dailryId" : 16,
   "title" : "오늘의 다일리"
 }, {
-  "dailryId" : 17,
+  "dailryId" : 16,
   "title" : "오늘의 다일리"
 } ]</code></pre>
 </div>
@@ -1881,7 +1881,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_21">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/pages HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/dailry/16/pages HTTP/1.1
 Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
@@ -1894,7 +1894,8 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 Content-Type: application/json;charset=UTF-8
 
 {
-  "dailryPageId" : 5,
+  "dailryId" : 16,
+  "pageId" : 5,
   "background" : "grid",
   "pageNumber" : 1
 }</code></pre>
@@ -1917,7 +1918,13 @@ Content-Type: application/json;charset=UTF-8
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dailryPageId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dailryId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다일리 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">다일리 페이지 id</p></td>
@@ -2084,7 +2091,7 @@ Content-Type: application/json
 Content-Type: application/json;charset=UTF-8
 
 {
-  "dailryPageId" : 5,
+  "pageId" : 5,
   "background" : "무지",
   "thumbnail" : "https://data.da-ily.site/thumbnail/5/1/awefkaweop",
   "pageNumber" : 1,
@@ -2162,7 +2169,7 @@ Content-Type: application/json;charset=UTF-8
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dailryPageId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">다일리 페이지 id</p></td>
@@ -2286,7 +2293,7 @@ Content-Type: application/json;charset=UTF-8
 Content-Type: application/json;charset=UTF-8
 
 {
-  "dailryPageId" : 5,
+  "pageId" : 5,
   "background" : "무지",
   "thumbnail" : "https://data.da-ily.site/thumbnail/5/1/awefkaweop",
   "pageNumber" : 1,
@@ -2364,7 +2371,7 @@ Content-Type: application/json;charset=UTF-8
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>dailryPageId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">다일리 페이지 id</p></td>
@@ -2490,12 +2497,15 @@ Content-Type: application/json;charset=UTF-8
 {
   "dailryId" : 2,
   "pages" : [ {
+    "pageId" : 1,
     "pageNumber" : 1,
     "thumbnail" : "https://data.da-ily.site/thumbnail/5/1/awerqlwp33124"
   }, {
+    "pageId" : 2,
     "pageNumber" : 2,
     "thumbnail" : "https://data.da-ily.site/thumbnail/5/2/73123wqrw"
   }, {
+    "pageId" : 3,
     "pageNumber" : 3,
     "thumbnail" : "https://data.da-ily.site/thumbnail/5/3/u12rgf31412"
   } ]
@@ -2529,6 +2539,12 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">미리보기 페이지 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pages[].pageId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다일리 페이지 id</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>pages[].pageNumber</code></p></td>
@@ -3392,10 +3408,10 @@ Content-Type: application/json;charset=UTF-8
 
 {
   "commentId" : 16,
-  "postId" : 3,
-  "writerId" : 13,
-  "writerNickname" : "일반회원2임",
-  "content" : "오오.. 오늘 계획 알차시네요!!",
+  "postId" : 4,
+  "writerId" : 10,
+  "writerNickname" : "gomudayya",
+  "content" : "오오 멋있어요",
   "createdTime" : "2024-01-20T06:52:30.000000004"
 }</code></pre>
 </div>
@@ -3523,9 +3539,9 @@ Content-Type: application/json;charset=UTF-8
 
 {
   "commentId" : 16,
-  "postId" : 3,
-  "writerId" : 13,
-  "writerNickname" : "일반회원2임",
+  "postId" : 4,
+  "writerId" : 10,
+  "writerNickname" : "gomudayya",
   "content" : "댓글 수정하기 ㅁㄴㅇㄹ",
   "createdTime" : "2024-01-20T06:52:30.000000004"
 }</code></pre>
@@ -3653,19 +3669,19 @@ Content-Type: application/json;charset=UTF-8
   "presentPage" : 0,
   "hasNext" : true,
   "comments" : [ {
-    "commentId" : 6,
-    "content" : "1번째 댓글입니다.",
-    "writerNickname" : "일반회원2임",
+    "commentId" : 2,
+    "content" : "와우",
+    "writerNickname" : "뚱냥이",
     "createdTime" : "2024-01-20T06:52:30.000000004"
   }, {
-    "commentId" : 12,
-    "content" : "2번째 댓글입니다.",
-    "writerNickname" : "일반회원2임",
+    "commentId" : 5,
+    "content" : "허걱",
+    "writerNickname" : "돼냥이",
     "createdTime" : "2024-01-20T06:52:30.000000004"
   }, {
-    "commentId" : 18,
-    "content" : "3번째 댓글입니다.",
-    "writerNickname" : "일반회원2임",
+    "commentId" : 16,
+    "content" : "오오 멋있어요",
+    "writerNickname" : "gomudayya",
     "createdTime" : "2024-01-20T06:52:30.000000004"
   } ]
 }</code></pre>
@@ -3783,7 +3799,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-01 13:08:01 +0900
+Last updated 2024-02-02 14:38:26 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static com.daily.daily.dailry.fixture.DailryFixture.DAILRY_ID;
 import static com.daily.daily.dailrypage.fixture.DailryPageFixture.*;
 import static com.daily.daily.post.fixture.PostFixture.게시글_요청_DTO_JSON_파일;
 import static com.daily.daily.post.fixture.PostFixture.다일리_페이지_이미지_파일;
@@ -69,7 +70,7 @@ class DailryPageControllerTest {
             given(dailryPageService.create2(any(), any())).willReturn(비어있는_다일리_페이지_DTO());
 
             //when
-            ResultActions perform = mockMvc.perform(post("/api/pages")
+            ResultActions perform = mockMvc.perform(post("/api/dailry/{dailryID}/pages", DAILRY_ID)
                     .with(csrf().asHeader())
             );
 

--- a/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
@@ -66,7 +66,7 @@ class DailryPageControllerTest {
         @DisplayName("다일리 페이지 생성 요청이 성공했을 때 응답값을 검사한다.")
         void test1() throws Exception {
             //given
-            given(dailryPageService.create()).willReturn(비어있는_다일리_페이지_DTO());
+            given(dailryPageService.create2(any(), any())).willReturn(비어있는_다일리_페이지_DTO());
 
             //when
             ResultActions perform = mockMvc.perform(post("/api/pages")

--- a/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
@@ -72,14 +72,14 @@ class DailryPageControllerTest {
             //then
             perform.andExpect(status().isCreated())
                     .andDo(print())
-                    .andExpect(jsonPath("$.dailryPageId").value(DAILRY_PAGE_ID))
+                    .andExpect(jsonPath("$.pageId").value(DAILRY_PAGE_ID))
                     .andExpect(jsonPath("$.background").value("grid"))
                     .andExpect(jsonPath("$.pageNumber").value(1));
 
             //restdocs
             perform.andDo(document("다일리 페이지 생성",
                     responseFields(
-                            fieldWithPath("dailryPageId").type(NUMBER).description("다일리 페이지 id"),
+                            fieldWithPath("pageId").type(NUMBER).description("다일리 페이지 id"),
                             fieldWithPath("background").type(STRING).description("페이지 배경"),
                             fieldWithPath("pageNumber").type(NUMBER).description("다일리 페이지 번호 (몇 페이지 인지)")
                     )
@@ -108,7 +108,7 @@ class DailryPageControllerTest {
             //then
             perform.andExpect(status().isOk())
                     .andDo(print())
-                    .andExpect(jsonPath("$.dailryPageId").value(DAILRY_PAGE_ID))
+                    .andExpect(jsonPath("$.pageId").value(DAILRY_PAGE_ID))
                     .andExpect(jsonPath("$.background").value("무지"))
                     .andExpect(jsonPath("$.pageNumber").value(1))
                     .andExpect(jsonPath("$.thumbnail").value("https://data.da-ily.site/thumbnail/5/1/awefkaweop"))
@@ -138,7 +138,7 @@ class DailryPageControllerTest {
                             fieldWithPath("elements[].typeContent").type(OBJECT).description("해당 element 타입별 개별속성")
                     ),
                     relaxedResponseFields(
-                            fieldWithPath("dailryPageId").type(NUMBER).description("다일리 페이지 id"),
+                            fieldWithPath("pageId").type(NUMBER).description("다일리 페이지 id"),
                             fieldWithPath("background").type(STRING).description("다일리 페이지 배경"),
                             fieldWithPath("pageNumber").type(NUMBER).description("다일리 페이지 번호 (몇 페이지 인지)"),
                             fieldWithPath("thumbnail").type(STRING).description("해당 페이지 썸네일 URL"),
@@ -175,7 +175,7 @@ class DailryPageControllerTest {
             //then
             perform.andExpect(status().isOk())
                     .andDo(print())
-                    .andExpect(jsonPath("$.dailryPageId").value(DAILRY_PAGE_ID))
+                    .andExpect(jsonPath("$.pageId").value(DAILRY_PAGE_ID))
                     .andExpect(jsonPath("$.background").value("무지"))
                     .andExpect(jsonPath("$.pageNumber").value(1))
                     .andExpect(jsonPath("$.thumbnail").value("https://data.da-ily.site/thumbnail/5/1/awefkaweop"))
@@ -187,7 +187,7 @@ class DailryPageControllerTest {
                             parameterWithName("pageId").description("다일리 페이지 id")
                     ),
                     relaxedResponseFields(
-                            fieldWithPath("dailryPageId").type(NUMBER).description("다일리 페이지 id"),
+                            fieldWithPath("pageId").type(NUMBER).description("다일리 페이지 id"),
                             fieldWithPath("background").type(STRING).description("다일리 페이지 배경"),
                             fieldWithPath("pageNumber").type(NUMBER).description("다일리 페이지 번호 (몇 페이지 인지)"),
                             fieldWithPath("thumbnail").type(STRING).description("해당 페이지 썸네일 URL"),

--- a/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
@@ -23,6 +23,7 @@ import static com.daily.daily.dailrypage.fixture.DailryPageFixture.*;
 import static com.daily.daily.testutil.document.RestDocsUtil.document;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.description;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
@@ -72,6 +73,7 @@ class DailryPageControllerTest {
             //then
             perform.andExpect(status().isCreated())
                     .andDo(print())
+                    .andExpect(jsonPath("$.dailryId").value(DAILRY_ID))
                     .andExpect(jsonPath("$.pageId").value(DAILRY_PAGE_ID))
                     .andExpect(jsonPath("$.background").value("grid"))
                     .andExpect(jsonPath("$.pageNumber").value(1));
@@ -79,6 +81,7 @@ class DailryPageControllerTest {
             //restdocs
             perform.andDo(document("다일리 페이지 생성",
                     responseFields(
+                            fieldWithPath("dailryId").type(NUMBER).description("다일리 id"),
                             fieldWithPath("pageId").type(NUMBER).description("다일리 페이지 id"),
                             fieldWithPath("background").type(STRING).description("페이지 배경"),
                             fieldWithPath("pageNumber").type(NUMBER).description("다일리 페이지 번호 (몇 페이지 인지)")
@@ -235,6 +238,7 @@ class DailryPageControllerTest {
                     responseFields(
                             fieldWithPath("dailryId").type(NUMBER).description("다일리 id"),
                             fieldWithPath("pages").type(ARRAY).description("미리보기 페이지 목록"),
+                            fieldWithPath("pages[].pageId").type(NUMBER).description("다일리 페이지 id"),
                             fieldWithPath("pages[].pageNumber").type(NUMBER).description("다일리 페이지 번호 (몇 페이지 인지)"),
                             fieldWithPath("pages[].thumbnail").type(STRING).description("썸네일 이미지 URL")
                     )

--- a/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
@@ -14,16 +14,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
-import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static com.daily.daily.dailry.fixture.DailryFixture.DAILRY_ID;
 import static com.daily.daily.dailrypage.fixture.DailryPageFixture.*;
-import static com.daily.daily.post.fixture.PostFixture.게시글_요청_DTO_JSON_파일;
-import static com.daily.daily.post.fixture.PostFixture.다일리_페이지_이미지_파일;
 import static com.daily.daily.testutil.document.RestDocsUtil.document;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -36,7 +32,6 @@ import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
-import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -67,7 +62,7 @@ class DailryPageControllerTest {
         @DisplayName("다일리 페이지 생성 요청이 성공했을 때 응답값을 검사한다.")
         void test1() throws Exception {
             //given
-            given(dailryPageService.create2(any(), any())).willReturn(비어있는_다일리_페이지_DTO());
+            given(dailryPageService.create(any(), any())).willReturn(비어있는_다일리_페이지_DTO());
 
             //when
             ResultActions perform = mockMvc.perform(post("/api/dailry/{dailryID}/pages", DAILRY_ID)

--- a/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
@@ -24,7 +24,7 @@ public class DailryPageFixture {
 
     public static DailryPageCreateResponseDTO 비어있는_다일리_페이지_DTO() {
         return DailryPageCreateResponseDTO.builder()
-                .dailryPageId(DAILRY_PAGE_ID)
+                .pageId(DAILRY_PAGE_ID)
                 .background("grid")
                 .pageNumber(1L)
                 .build();
@@ -59,7 +59,7 @@ public class DailryPageFixture {
 
     public static DailryPageDTO 다일리_페이지_응답_DTO() {
         return DailryPageDTO.builder()
-                .dailryPageId(DAILRY_PAGE_ID)
+                .pageId(DAILRY_PAGE_ID)
                 .background("무지")
                 .thumbnail("https://data.da-ily.site/thumbnail/5/1/awefkaweop")
                 .pageNumber(1)

--- a/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.daily.daily.dailry.fixture.DailryFixture.DAILRY_ID;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
 
@@ -24,6 +25,7 @@ public class DailryPageFixture {
 
     public static DailryPageCreateResponseDTO 비어있는_다일리_페이지_DTO() {
         return DailryPageCreateResponseDTO.builder()
+                .dailryId(DAILRY_ID)
                 .pageId(DAILRY_PAGE_ID)
                 .background("grid")
                 .pageNumber(1L)
@@ -68,9 +70,9 @@ public class DailryPageFixture {
     }
 
     public static DailryPagePreviewDTO 다일리_페이지_미리보기_DTO() {
-        DailryPageThumbnailDTO 썸네일1 = new DailryPageThumbnailDTO(1, "https://data.da-ily.site/thumbnail/5/1/awerqlwp33124");
-        DailryPageThumbnailDTO 썸네일2 = new DailryPageThumbnailDTO(2, "https://data.da-ily.site/thumbnail/5/2/73123wqrw");
-        DailryPageThumbnailDTO 썸네일3 = new DailryPageThumbnailDTO(3, "https://data.da-ily.site/thumbnail/5/3/u12rgf31412");
+        DailryPageThumbnailDTO 썸네일1 = new DailryPageThumbnailDTO(1,1, "https://data.da-ily.site/thumbnail/5/1/awerqlwp33124");
+        DailryPageThumbnailDTO 썸네일2 = new DailryPageThumbnailDTO(2,2, "https://data.da-ily.site/thumbnail/5/2/73123wqrw");
+        DailryPageThumbnailDTO 썸네일3 = new DailryPageThumbnailDTO(3,3, "https://data.da-ily.site/thumbnail/5/3/u12rgf31412");
 
         DailryPagePreviewDTO 다일리_페이지_미리보기_DTO = new DailryPagePreviewDTO();
         다일리_페이지_미리보기_DTO.setDailryId(2L);

--- a/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
@@ -70,9 +70,9 @@ public class DailryPageFixture {
     }
 
     public static DailryPagePreviewDTO 다일리_페이지_미리보기_DTO() {
-        DailryPageThumbnailDTO 썸네일1 = new DailryPageThumbnailDTO(1,1, "https://data.da-ily.site/thumbnail/5/1/awerqlwp33124");
-        DailryPageThumbnailDTO 썸네일2 = new DailryPageThumbnailDTO(2,2, "https://data.da-ily.site/thumbnail/5/2/73123wqrw");
-        DailryPageThumbnailDTO 썸네일3 = new DailryPageThumbnailDTO(3,3, "https://data.da-ily.site/thumbnail/5/3/u12rgf31412");
+        DailryPageThumbnailDTO 썸네일1 = new DailryPageThumbnailDTO(1L,1, "https://data.da-ily.site/thumbnail/5/1/awerqlwp33124");
+        DailryPageThumbnailDTO 썸네일2 = new DailryPageThumbnailDTO(2L,2, "https://data.da-ily.site/thumbnail/5/2/73123wqrw");
+        DailryPageThumbnailDTO 썸네일3 = new DailryPageThumbnailDTO(3L,3, "https://data.da-ily.site/thumbnail/5/3/u12rgf31412");
 
         DailryPagePreviewDTO 다일리_페이지_미리보기_DTO = new DailryPagePreviewDTO();
         다일리_페이지_미리보기_DTO.setDailryId(2L);


### PR DESCRIPTION
## 연관 이슈
close: #216 
## 작업 내용
- 다일리 생성 API 엔드포인트를 수정 (`/api/pages` -> `/api/dailry/{dailryID}/pages`)
- API응답 파라미터 `dailryPageId` -> `pageId`로 변경
-  다일리 페이지 생성 응답값에 `dailryId` 추가
-  다일리 썸네일 미리보기 응답값에 `pageId` 추가
   - `DailryPageRepository` 에서 썸네일을 가져오는 메서드를 Querydsl로 변경했습니다. 
   - 이유는 projection 대상으로 `pageId`까지 추가되니까 스프링 데이터 JPA의 쿼리메소드 기능으로는 버겁더라구요.
   - 해당 인터페이스는 `List<DailryPageThumbnailDTO> findThumbnails(Long dailryId);` 입니다.

## 의논할 거리
## Merge 전에 해야할 작업
## 기타
