### PR TITLE
깃 서브모듈 업데이트(도메인 변수 재설정)

### DIFF
--- a/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
@@ -123,7 +123,7 @@ class DailryPageControllerTest {
                             parameterWithName("pageId").description("다일리 페이지 id")
                     ),
                     requestParts(
-                            partWithName("thumbnail").description("다일리 페이지 섬네일 파일"),
+                            partWithName("thumbnail").description("다일리 페이지 썸네일 파일 (MIME 타입 'image/**' 만가능)"),
                             partWithName("dailryPageRequest").description("다일리 페이지 수정 요청 데이터 (JSON)")
                     ),
                     relaxedRequestPartFields(

--- a/backend/src/test/java/com/daily/daily/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/PostControllerTest.java
@@ -97,7 +97,7 @@ class PostControllerTest {
         //restdocs
         perform.andDo(document("게시글 작성",
                 requestParts(
-                        partWithName("pageImage").description("다일리 페이지 이미지 파일"),
+                        partWithName("pageImage").description("다일리 페이지 이미지 파일 (MIME 타입 'image/**' 만가능)"),
                         partWithName("request").description("게시글 작성 요청 데이터 (JSON)")
                 ),
                 requestPartFields(
@@ -151,7 +151,7 @@ class PostControllerTest {
                             parameterWithName("postId").description("게시글 id")
                     ),
                     requestParts(
-                            partWithName("pageImage").description("다일리 페이지 이미지 파일"),
+                            partWithName("pageImage").description("다일리 페이지 이미지 파일 (MIME 타입 'image/**' 만가능)"),
                             partWithName("request").description("게시글 수정 요청 데이터 (JSON)")
                     ),
                     requestPartFields(


### PR DESCRIPTION
## 연관 이슈
x
## 작업 내용
서브모듈을 업데이트 했습니다.
도메인 이름 설정할 때 특수문자가 사용되면 안되네요
https://da-ily.site -> da-ily.site 로 변경했습니다.

 +) restdocs 이미지 파일 관련 제한사항 docs 수정했습니다.
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
