### PR TITLE
꾸미기 컴포넌트 내용 편집 리팩터링

### DIFF
--- a/frontend/src/hooks/useModifyDecorateComponent.jsx
+++ b/frontend/src/hooks/useModifyDecorateComponent.jsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+const useModifyDecorateComponent = (setDecorateComponents) => {
+  const [canEditDecorateComponent, setCanEditDecorateComponent] =
+    useState(undefined);
+  const modifyDecorateComponentTypeContent = (newTypeContent) => {
+    setDecorateComponents((prev) =>
+      prev.map((decorateComponent) => {
+        return decorateComponent.id === canEditDecorateComponent.id
+          ? { ...decorateComponent, typeContent: newTypeContent }
+          : decorateComponent;
+      }),
+    );
+  };
+
+  return {
+    canEditDecorateComponent,
+    setCanEditDecorateComponent,
+    modifyDecorateComponentTypeContent,
+  };
+};
+
+export default useModifyDecorateComponent;

--- a/frontend/src/hooks/useModifyDecorateComponent.jsx
+++ b/frontend/src/hooks/useModifyDecorateComponent.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 const useModifyDecorateComponent = (setDecorateComponents) => {
   const [canEditDecorateComponent, setCanEditDecorateComponent] =
-    useState(undefined);
+    useState(null);
   const modifyDecorateComponentTypeContent = (newTypeContent) => {
     setDecorateComponents((prev) =>
       prev.map((decorateComponent) => {

--- a/frontend/src/hooks/useNewDecorateComponent/useCompleteCreation.jsx
+++ b/frontend/src/hooks/useNewDecorateComponent/useCompleteCreation.jsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+const useCompleteCreation = (
+  newDecorateComponent,
+  setDecorateComponents,
+  initializeNewDecorateComponent,
+) => {
+  const [isOtherActionTriggered, setIsOtherActionTriggered] = useState(false);
+  const isCreationCompleted =
+    newDecorateComponent?.typeContent &&
+    Object.values(newDecorateComponent?.typeContent).every((v) => v !== null);
+
+  useEffect(() => {
+    if (isCreationCompleted) {
+      setDecorateComponents((prev) => prev.concat(newDecorateComponent));
+    }
+    initializeNewDecorateComponent();
+  }, [isOtherActionTriggered]);
+
+  return { setIsOtherActionTriggered };
+};
+
+export default useCompleteCreation;

--- a/frontend/src/hooks/useNewDecorateComponent/useNewDecorateComponent.jsx
+++ b/frontend/src/hooks/useNewDecorateComponent/useNewDecorateComponent.jsx
@@ -2,12 +2,16 @@ import { useState } from 'react';
 import { typedDecorateComponentProperties } from './properties';
 import { getCommonDecorateComponentProperties } from './createNewDecorateComponent';
 
-const useNewDecorateComponent = (decorateComponents, pageRef) => {
+const useNewDecorateComponent = (
+  decorateComponents,
+  setDecorateComponents,
+  pageRef,
+) => {
   const [newDecorateComponent, setNewDecorateComponent] = useState(undefined);
 
-  const isEdited =
-    newDecorateComponent &&
-    Object.values(newDecorateComponent).every((v) => v !== null);
+  const initializeNewDecorateComponent = () => {
+    setNewDecorateComponent(undefined);
+  };
 
   const createNewDecorateComponent = (e, type) => {
     setNewDecorateComponent({
@@ -17,11 +21,19 @@ const useNewDecorateComponent = (decorateComponents, pageRef) => {
       ...typedDecorateComponentProperties[type],
     });
   };
+
+  const setNewDecorateComponentTypeContent = (newTypeContent) => {
+    setNewDecorateComponent((prev) => ({
+      ...prev,
+      typeContent: newTypeContent,
+    }));
+  };
+
   return {
-    isEdited,
     createNewDecorateComponent,
     newDecorateComponent,
-    setNewDecorateComponent,
+    initializeNewDecorateComponent,
+    setNewDecorateComponentTypeContent,
   };
 };
 

--- a/frontend/src/hooks/useSetTypeContent.jsx
+++ b/frontend/src/hooks/useSetTypeContent.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { DECORATE_TYPE } from '../constants/decorateComponent';
+
+const useSetTypeContent = (
+  selectedTool,
+  newDecorateComponent,
+  setNewDecorateComponentTypeContent,
+  modifyDecorateComponentTypeContent,
+) => {
+  const [newTypeContent, setNewTypeContent] = useState(undefined);
+  useEffect(() => {
+    if (selectedTool === DECORATE_TYPE.MOVING) {
+      return;
+    }
+    if (newDecorateComponent && newTypeContent) {
+      setNewDecorateComponentTypeContent(newTypeContent);
+
+      return;
+    }
+
+    modifyDecorateComponentTypeContent();
+  }, [newTypeContent]);
+
+  return { setNewTypeContent };
+};
+
+export default useSetTypeContent;

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -12,6 +12,7 @@ import { DECORATE_TYPE } from '../../constants/decorateComponent';
 import useNewDecorateComponent from '../../hooks/useNewDecorateComponent/useNewDecorateComponent';
 import DecorateWrapper from '../../components/decorate/DecorateWrapper';
 import TypedDecorateComponent from '../../components/decorate/TypedDecorateComponent';
+import useCompleteCreation from '../../hooks/useNewDecorateComponent/useCompleteCreation';
 
 const DailryPage = () => {
   const pageRef = useRef(null);
@@ -28,8 +29,19 @@ const DailryPage = () => {
   const {
     createNewDecorateComponent,
     newDecorateComponent,
-    setNewDecorateComponent,
-  } = useNewDecorateComponent(decorateComponents, pageRef);
+    initializeNewDecorateComponent,
+    setNewDecorateComponentTypeContent,
+  } = useNewDecorateComponent(
+    decorateComponents,
+    setDecorateComponents,
+    pageRef,
+  );
+
+  const { setIsOtherActionTriggered } = useCompleteCreation(
+    newDecorateComponent,
+    setDecorateComponents,
+    initializeNewDecorateComponent,
+  );
 
   const isMoveable = () => target && selectedTool === DECORATE_TYPE.MOVING;
 
@@ -53,24 +65,6 @@ const DailryPage = () => {
     });
   };
 
-  const isNewDecorateComponentCompleted =
-    newDecorateComponent?.typeContent &&
-    Object.values(newDecorateComponent?.typeContent).every((v) => v !== null);
-
-  const addNewDecorateComponent = () => {
-    if (isNewDecorateComponentCompleted) {
-      setDecorateComponents((prev) => prev.concat(newDecorateComponent));
-    }
-    setNewDecorateComponent(undefined);
-  };
-
-  const setNewDecorateComponentTypeContent = () => {
-    setNewDecorateComponent((prev) => ({
-      ...prev,
-      typeContent: newTypeContent,
-    }));
-  };
-
   const modifyDecorateComponentTypeContent = () => {
     setDecorateComponents((prev) =>
       prev.map((c) => {
@@ -91,7 +85,7 @@ const DailryPage = () => {
     }
 
     if (newDecorateComponent) {
-      addNewDecorateComponent();
+      setIsOtherActionTriggered((prev) => !prev);
       return;
     }
 
@@ -103,7 +97,7 @@ const DailryPage = () => {
     setTarget(index + 1);
 
     if (newDecorateComponent) {
-      addNewDecorateComponent();
+      setIsOtherActionTriggered((prev) => !prev);
     }
   };
 
@@ -112,7 +106,7 @@ const DailryPage = () => {
       return;
     }
     if (newDecorateComponent && newTypeContent) {
-      setNewDecorateComponentTypeContent();
+      setNewDecorateComponentTypeContent(newTypeContent);
 
       return;
     }
@@ -182,8 +176,8 @@ const DailryPage = () => {
                 setTimeout(() => setSelectedTool(null), 150);
               }
               if (newDecorateComponent) {
-                    addNewDecorateComponent();
-                  }
+                setIsOtherActionTriggered((prev) => !prev);
+              }
               setSelectedTool(selectedTool === t ? null : t);
               setCanEditDecorateComponent(undefined);
             };

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -1,5 +1,5 @@
 // Da-ily 회원, 비회원, 다일리 있을때, 없을때를 조건문으로 나눠서 렌더링
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef } from 'react';
 import Moveable from '../../components/da-ily/Moveable/Moveable';
 import * as S from './DailryPage.styled';
 import ToolButton from '../../components/da-ily/ToolButton/ToolButton';
@@ -14,13 +14,13 @@ import DecorateWrapper from '../../components/decorate/DecorateWrapper';
 import TypedDecorateComponent from '../../components/decorate/TypedDecorateComponent';
 import useCompleteCreation from '../../hooks/useNewDecorateComponent/useCompleteCreation';
 import useModifyDecorateComponent from '../../hooks/useModifyDecorateComponent';
+import useSetTypeContent from '../../hooks/useSetTypeContent';
 
 const DailryPage = () => {
   const pageRef = useRef(null);
   const moveableRef = useRef([]);
 
   const [target, setTarget] = useState(null);
-  const [newTypeContent, setNewTypeContent] = useState(undefined);
   const [decorateComponents, setDecorateComponents] = useState([]);
 
   const [selectedTool, setSelectedTool] = useState(null);
@@ -42,6 +42,13 @@ const DailryPage = () => {
     setCanEditDecorateComponent,
     modifyDecorateComponentTypeContent,
   } = useModifyDecorateComponent(setDecorateComponents);
+
+  const { setNewTypeContent } = useSetTypeContent(
+    selectedTool,
+    newDecorateComponent,
+    setNewDecorateComponentTypeContent,
+    modifyDecorateComponentTypeContent,
+  );
 
   const { setIsOtherActionTriggered } = useCompleteCreation(
     newDecorateComponent,
@@ -96,19 +103,6 @@ const DailryPage = () => {
       setIsOtherActionTriggered((prev) => !prev);
     }
   };
-
-  useEffect(() => {
-    if (selectedTool === DECORATE_TYPE.MOVING) {
-      return;
-    }
-    if (newDecorateComponent && newTypeContent) {
-      setNewDecorateComponentTypeContent(newTypeContent);
-
-      return;
-    }
-
-    modifyDecorateComponentTypeContent();
-  }, [newTypeContent]);
 
   return (
     <S.FlexWrapper>

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -13,6 +13,7 @@ import useNewDecorateComponent from '../../hooks/useNewDecorateComponent/useNewD
 import DecorateWrapper from '../../components/decorate/DecorateWrapper';
 import TypedDecorateComponent from '../../components/decorate/TypedDecorateComponent';
 import useCompleteCreation from '../../hooks/useNewDecorateComponent/useCompleteCreation';
+import useModifyDecorateComponent from '../../hooks/useModifyDecorateComponent';
 
 const DailryPage = () => {
   const pageRef = useRef(null);
@@ -21,8 +22,7 @@ const DailryPage = () => {
   const [target, setTarget] = useState(null);
   const [newTypeContent, setNewTypeContent] = useState(undefined);
   const [decorateComponents, setDecorateComponents] = useState([]);
-  const [canEditDecorateComponent, setCanEditDecorateComponent] =
-    useState(undefined);
+
   const [selectedTool, setSelectedTool] = useState(null);
   const { currentDailry, setCurrentDailry } = useDailryContext();
 
@@ -36,6 +36,12 @@ const DailryPage = () => {
     setDecorateComponents,
     pageRef,
   );
+
+  const {
+    canEditDecorateComponent,
+    setCanEditDecorateComponent,
+    modifyDecorateComponentTypeContent,
+  } = useModifyDecorateComponent(setDecorateComponents);
 
   const { setIsOtherActionTriggered } = useCompleteCreation(
     newDecorateComponent,
@@ -63,16 +69,6 @@ const DailryPage = () => {
       }
       setCurrentDailry({ dailryId, pageId: pageId + 1 });
     });
-  };
-
-  const modifyDecorateComponentTypeContent = () => {
-    setDecorateComponents((prev) =>
-      prev.map((c) => {
-        return c.id === canEditDecorateComponent.id
-          ? { ...c, typeContent: newTypeContent }
-          : c;
-      }),
-    );
   };
 
   const handleClickPage = (e) => {

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -84,7 +84,7 @@ const DailryPage = () => {
     }
 
     if (canEditDecorateComponent) {
-      setCanEditDecorateComponent(undefined);
+      setCanEditDecorateComponent(null);
     }
 
     if (newDecorateComponent) {
@@ -169,7 +169,7 @@ const DailryPage = () => {
                 setIsOtherActionTriggered((prev) => !prev);
               }
               setSelectedTool(selectedTool === t ? null : t);
-              setCanEditDecorateComponent(undefined);
+              setCanEditDecorateComponent(null);
             };
             return (
               <ToolButton


### PR DESCRIPTION
## 연관 이슈
close: #223 
## 작업 내용
- 새로운 꾸미기 컴포넌트 생성 완료 커스텀 훅 추가
   - useCompleteCreation
      - isOtherActionTriggered 상태
         - 다른 액션이 실행될 때, 해당 상태를 업데이트 하여, 생성이 완료되었다면 꾸미기 컴포넌트 배열에 추가, 그렇지 않다면 삭제
      - 기존 useNewDecorateComponent 내부에 있던 생성 여부를 확인 하는 isCreationCompleted 이동
      - 상위 컴포넌트에서 실행되던 addNewDecorateComponent 함수 이동
- 꾸미기 컴포넌트 수정 커스텀 훅 추가
   - useModifyDecorateComponent
      - 상위 컴포넌트에서 실행되던 modifyDecorateComponentTypeContent 함수 이동
      - 상위 컴포넌트에 있던 canEditDecorateComponent 상태 이동
- 꾸미기 컴포넌트 내용 편집 커스텀 훅 추가
   - useSetTypeContent
      - 생성/수정 에 따라 새로운 꾸미기 컴포넌트/기존 꾸미기 컴포넌트 의 내용 편집 하는 기능
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
