### PR TITLE
react-toastify 사용

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^18.2.0",
     "react-moveable": "^0.56.0",
     "react-router-dom": "^6.20.1",
+    "react-toastify": "^10.0.4",
     "styled-components": "^6.1.1",
     "web-vitals": "^2.1.4",
     "yup": "^1.3.3"

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
 import GlobalStyles from './styles/GlobalStyle';
 import App from './App';
 import { worker } from './mocks/worker';
@@ -17,6 +18,7 @@ root.render(
     <DailryProvider>
       <BrowserRouter>
         <App />
+        <ToastContainer />
       </BrowserRouter>
     </DailryProvider>
   </StrictMode>,

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -2,7 +2,7 @@
 import { useState, useRef, useEffect } from 'react';
 import html2canvas from 'html2canvas';
 import saveAs from 'file-saver';
-import { ToastContainer, toast, Zoom } from 'react-toastify';
+import { toast, Zoom } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Moveable from '../../components/da-ily/Moveable/Moveable';
 import * as S from './DailryPage.styled';
@@ -240,7 +240,6 @@ const DailryPage = () => {
           })}
         </S.ToolWrapper>
         <S.ArrowWrapper>
-          <ToastContainer />
           <S.ArrowButton direction={'left'} onClick={handleLeftArrowClick}>
             <LeftArrowIcon />
           </S.ArrowButton>

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -2,6 +2,8 @@
 import { useState, useRef, useEffect } from 'react';
 import html2canvas from 'html2canvas';
 import saveAs from 'file-saver';
+import { ToastContainer, toast, Zoom } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import Moveable from '../../components/da-ily/Moveable/Moveable';
 import * as S from './DailryPage.styled';
 import ToolButton from '../../components/da-ily/ToolButton/ToolButton';
@@ -68,9 +70,19 @@ const DailryPage = () => {
     getPages(dailryId).then((response) => setPageList(response.data.pages));
   }, [dailryId, pageId, showPageModal]);
 
+  const toastify = (message) => {
+    toast(message, {
+      position: 'bottom-right',
+      autoClose: 300,
+      hideProgressBar: true,
+      closeOnClick: true,
+      transition: Zoom,
+    });
+  };
+
   const handleLeftArrowClick = () => {
     if (pageId === 1) {
-      console.log('첫 번째 페이지입니다');
+      toastify('첫 번째 페이지입니다');
       return;
     }
     setCurrentDailry({ dailryId, pageId: pageId - 1 });
@@ -78,7 +90,7 @@ const DailryPage = () => {
 
   const handleRightArrowClick = () => {
     if (pageList.length === pageId) {
-      console.log('마지막 페이지입니다');
+      toastify('마지막 페이지입니다');
       return;
     }
     setCurrentDailry({ dailryId, pageId: pageId + 1 });
@@ -228,6 +240,7 @@ const DailryPage = () => {
           })}
         </S.ToolWrapper>
         <S.ArrowWrapper>
+          <ToastContainer />
           <S.ArrowButton direction={'left'} onClick={handleLeftArrowClick}>
             <LeftArrowIcon />
           </S.ArrowButton>


### PR DESCRIPTION
## 연관 이슈
close: #229
## 작업 내용
`react-toastify`를 사용해 다일리 페이지 넘길 때 처음과 끝에서 메세지 띄움

```JavaScript
// react-toastify 사용법
// 1. import
import { toast } from 'react-toastify';
import 'react-toastify/dist/ReactToastify.css';

// 2. toast 함수 정의
const toastify = () => {
  toast('토스트 메세지', {
    position: 'bottom-right',
    autoClose: 300,
  });
};

// 3. 이벤트 달기
<button onClick={toastify} />

// 4. ToastContainer 렌더링. index.js에 한번만 넣으면 어디서나 사용가능하므로 따로 추가하지 않아도 됨
return <ToastContainer />
```

## 의논할 거리
## Merge 전에 해야할 작업
## 기타
