### PR TITLE
새로운 꾸미기 컴포넌트 생성 시 순서, 각도 초기 값 지정

### DIFF
--- a/frontend/src/components/decorate/DecorateWrapper.jsx
+++ b/frontend/src/components/decorate/DecorateWrapper.jsx
@@ -9,6 +9,7 @@ const DecorateWrapper = forwardRef((props, ref) => {
     order,
     position,
     size,
+    rotation,
     typeContent,
     canEdit,
     onMouseDown,
@@ -27,6 +28,7 @@ const DecorateWrapper = forwardRef((props, ref) => {
         order,
         size,
         canEdit,
+        rotation,
       })}
     >
       {children}
@@ -47,6 +49,7 @@ DecorateWrapper.propTypes = {
   position: PropTypes.object,
   typeContent: PropTypes.object,
   order: PropTypes.number,
+  rotation: PropTypes.string,
   size: PropTypes.object,
   canEdit: PropTypes.bool,
   onMouseDown: PropTypes.func,

--- a/frontend/src/hooks/useNewDecorateComponent/properties.js
+++ b/frontend/src/hooks/useNewDecorateComponent/properties.js
@@ -9,7 +9,7 @@ export const commonDecorateComponentProperties = {
     x: null,
     y: null,
   },
-  rotation: null,
+  rotation: '0deg',
 };
 
 export const typedDecorateComponentProperties = {

--- a/frontend/src/hooks/useNewDecorateComponent/useCompleteCreation.jsx
+++ b/frontend/src/hooks/useNewDecorateComponent/useCompleteCreation.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 const useCompleteCreation = (
   newDecorateComponent,
   addNewDecorateComponent,
-  initializeNewDecorateComponent,
+  removeNewDecorateComponent,
   addUpdatedDecorateComponent,
 ) => {
   const [isOtherActionTriggered, setIsOtherActionTriggered] = useState(false);
@@ -16,7 +16,7 @@ const useCompleteCreation = (
       addNewDecorateComponent(newDecorateComponent);
       addUpdatedDecorateComponent(newDecorateComponent);
     }
-    initializeNewDecorateComponent();
+    removeNewDecorateComponent();
   }, [isOtherActionTriggered]);
 
   return { setIsOtherActionTriggered };

--- a/frontend/src/hooks/useNewDecorateComponent/useNewDecorateComponent.jsx
+++ b/frontend/src/hooks/useNewDecorateComponent/useNewDecorateComponent.jsx
@@ -3,10 +3,10 @@ import { typedDecorateComponentProperties } from './properties';
 import { getCommonDecorateComponentProperties } from './createNewDecorateComponent';
 
 const useNewDecorateComponent = (decorateComponents, pageRef) => {
-  const [newDecorateComponent, setNewDecorateComponent] = useState(undefined);
+  const [newDecorateComponent, setNewDecorateComponent] = useState(null);
 
-  const initializeNewDecorateComponent = () => {
-    setNewDecorateComponent(undefined);
+  const removeNewDecorateComponent = () => {
+    setNewDecorateComponent(null);
   };
 
   const createNewDecorateComponent = (e, type) => {
@@ -28,7 +28,7 @@ const useNewDecorateComponent = (decorateComponents, pageRef) => {
   return {
     createNewDecorateComponent,
     newDecorateComponent,
-    initializeNewDecorateComponent,
+    removeNewDecorateComponent,
     setNewDecorateComponentTypeContent,
   };
 };

--- a/frontend/src/hooks/useNewDecorateComponent/useNewDecorateComponent.jsx
+++ b/frontend/src/hooks/useNewDecorateComponent/useNewDecorateComponent.jsx
@@ -2,11 +2,7 @@ import { useState } from 'react';
 import { typedDecorateComponentProperties } from './properties';
 import { getCommonDecorateComponentProperties } from './createNewDecorateComponent';
 
-const useNewDecorateComponent = (
-  decorateComponents,
-  setDecorateComponents,
-  pageRef,
-) => {
+const useNewDecorateComponent = (decorateComponents, pageRef) => {
   const [newDecorateComponent, setNewDecorateComponent] = useState(undefined);
 
   const initializeNewDecorateComponent = () => {
@@ -15,10 +11,10 @@ const useNewDecorateComponent = (
 
   const createNewDecorateComponent = (e, type) => {
     setNewDecorateComponent({
-      type,
-      order: decorateComponents.length,
       ...getCommonDecorateComponentProperties(e, pageRef),
       ...typedDecorateComponentProperties[type],
+      type,
+      order: decorateComponents.length,
     });
   };
 

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -38,7 +38,6 @@ const DailryPage = () => {
 
   const {
     decorateComponents,
-    setDecorateComponents,
     addNewDecorateComponent,
     modifyDecorateComponentTypeContent,
   } = useDecorateComponents();
@@ -48,11 +47,7 @@ const DailryPage = () => {
     createNewDecorateComponent,
     initializeNewDecorateComponent,
     setNewDecorateComponentTypeContent,
-  } = useNewDecorateComponent(
-    decorateComponents,
-    setDecorateComponents,
-    pageRef,
-  );
+  } = useNewDecorateComponent(decorateComponents, pageRef);
 
   const { setIsOtherActionTriggered } = useCompleteCreation(
     newDecorateComponent,

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -45,14 +45,14 @@ const DailryPage = () => {
   const {
     newDecorateComponent,
     createNewDecorateComponent,
-    initializeNewDecorateComponent,
+    removeNewDecorateComponent,
     setNewDecorateComponentTypeContent,
   } = useNewDecorateComponent(decorateComponents, pageRef);
 
   const { setIsOtherActionTriggered } = useCompleteCreation(
     newDecorateComponent,
     addNewDecorateComponent,
-    initializeNewDecorateComponent,
+    removeNewDecorateComponent,
     addUpdatedDecorateComponent,
   );
 

--- a/frontend/src/pages/DailryPage/DailryPage.styled.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.styled.jsx
@@ -30,7 +30,7 @@ export const CanvasWrapper = styled.div`
   }
 `;
 
-export const ElementStyle = ({ position, order, size, canEdit }) => {
+export const ElementStyle = ({ position, order, size, rotation, canEdit }) => {
   return {
     position: 'absolute',
     left: position.x,
@@ -39,6 +39,7 @@ export const ElementStyle = ({ position, order, size, canEdit }) => {
     height: size.height,
     zIndex: order,
     border: canEdit ? `2px dashed #74ABD9` : '',
+    transform: `rotate(${rotation})`,
   };
 };
 


### PR DESCRIPTION
## 연관 이슈
close: #234 
## 작업 내용
* 새로운 꾸미기 컴포넌트 생성 시 순서, 각도 초기 값 지정
   - `순서` : `꾸미기 컴포넌트 배열` 의 길이 를 순서로 지정
   - `각도` : `'0deg'`
* `useNewDecorateComponent` 커스텀 훅 수정
   - `initializeNewDecorateComponent` -> `removeNewDecorateComponent`
       - 새로운 꾸미기 컴포넌트를 삭제하는 의미에서 더 적합하여 수정
* `newDecorateComponent` 초기값 `null` 로 수정
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
