### PR TITLE
CorsConfig 에서 Profile 별로 설정 빈을 다르게 등록하기

### DIFF
--- a/backend/src/main/java/com/daily/daily/auth/config/CorsConfig.java
+++ b/backend/src/main/java/com/daily/daily/auth/config/CorsConfig.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Configuration
 public class CorsConfig {
-    @Bean
+    @Bean(name = "corsConfigurationSource")
     @Profile({"local", "dev"})
     public CorsConfigurationSource localDevCorsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
@@ -28,7 +28,7 @@ public class CorsConfig {
         return source;
     }
 
-    @Bean
+    @Bean(name = "corsConfigurationSource")
     @Profile({"prod"})
     public CorsConfigurationSource prodCorsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();

--- a/backend/src/main/java/com/daily/daily/auth/config/CorsConfig.java
+++ b/backend/src/main/java/com/daily/daily/auth/config/CorsConfig.java
@@ -2,24 +2,43 @@ package com.daily.daily.auth.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
 
 import java.util.List;
 
 @Configuration
 public class CorsConfig {
     @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
+    @Profile({"local", "dev"})
+    public CorsConfigurationSource localDevCorsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://localhost:3000"));
+        configuration.setAllowedOrigins(List.of("http://127.0.0.1:3000", "http://localhost:3000", "https://localhost:3000", "https://da-ily.site"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("*"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+
+    @Bean
+    @Profile({"prod"})
+    public CorsConfigurationSource prodCorsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedOrigins(List.of("https://dailry.co.kr"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("*"));
+        configuration.setMaxAge(1800L); // preflight 요청을 30분 동안 캐싱. 불필요한 preflight 요청 감소
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
## 연관 이슈
close: #245 
## 작업 내용
**[local, dev] 환경**
```java
configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://localhost:3000", "https://da-ily.site"));
```
**[prod] 환경**
```java
...
configuration.setAllowedOrigins(List.of("https://dailry.co.kr"));
configuration.setMaxAge(1800L); // preflight 요청을 30분 동안 캐싱. 불필요한 preflight 요청 감소
...
```

cors 요청을 보낼 때에는 클라이언트와 서버가 서로 요청을 주고 받아도 되는지 확인하기 위해
실제 요청 이전에 클라이언트 측에서 preflight 요청을 먼저 보냅니다.

그런데 `configuration.setMaxAge(1800L);` 설정을 하지 않으면 매번 서버에 요청할 때 마다 preflight 요청을 보내는 것 같네요

`configuration.setMaxAge(설정시간)` 메서드는 preflight 요청을 설정 시간 동안 브라우저에 캐싱하도록 한다고 합니다.
브라우저는 캐싱되어있는 preflight 요청이 있으면 그 다음부턴 preflight 요청을 보내지 않고, 바로 실제 요청을 보내는 것 같아요


## 의논할 거리
## Merge 전에 해야할 작업
## 기타
