### PR TITLE
백엔드 Github Action CI 전용 스크립트 생성

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,35 @@
+name: backend-ci
+  pull_request:
+    paths:
+      - 'backend/**'
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: backend
+    services:
+      mysql:
+        image: mysql:8.0.33
+        env:
+          MYSQL_ROOT_PASSWORD: 1234
+          MYSQL_DATABASE: dailry
+        ports:
+          - 3306:3306
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GIT_TOKEN }}
+          submodules: true
+      - name: Set up JDK 17 for x64
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          architecture: x64
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,4 +1,5 @@
 name: backend-ci
+on: 
   pull_request:
     paths:
       - 'backend/**'

--- a/.github/workflows/backend-dev-cicd.yml
+++ b/.github/workflows/backend-dev-cicd.yml
@@ -14,6 +14,14 @@ jobs:
     defaults:
       run:
         working-directory: backend
+    services:
+      mysql:
+        image: mysql:8.0.33
+        env:
+          MYSQL_ROOT_PASSWORD: 1234
+          MYSQL_DATABASE: dailry
+        ports:
+          - 3306:3306
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/backend-prod-cicd.yml
+++ b/.github/workflows/backend-prod-cicd.yml
@@ -13,6 +13,14 @@ jobs:
     defaults:
       run:
         working-directory: backend
+    services:
+      mysql:
+        image: mysql:8.0.33
+        env:
+          MYSQL_ROOT_PASSWORD: 1234
+          MYSQL_DATABASE: dailry
+        ports:
+          - 3306:3306
     steps:
       - uses: actions/checkout@v4
         with:

--- a/backend/src/main/java/com/daily/daily/common/service/CookieService.java
+++ b/backend/src/main/java/com/daily/daily/common/service/CookieService.java
@@ -17,7 +17,7 @@ public class CookieService {
     @Value("${app.properties.mainDomain}")
     private String mainDomain;
 
-    @Value("${app.properties.cookie.sameSite}")
+    @Value("${app.properties.cookie.sameSite: Strict}")
     private String sameSite;
 
     public ResponseCookie createCookie(String cookieName, String cookieValue) {


### PR DESCRIPTION
## 연관 이슈
close: #248 
## 작업 내용

- PR이 올라왔을 때, PR이 올라온 브랜치가 제대로 Build 되는지 검증하는 CI 스크립트 작성

작성한 이유는 이슈 참고.

## 의논할 거리
## Merge 전에 해야할 작업
## 기타
추가로 한일

- 모든 백엔드 workflow를 GithubAction Runner 환경에서 mysql 이미지를 띄운 다음에 빌드하도록 변경
   - 이유는 jpa ddl-auto : validate 기능을 쓰기 위함. 
   - h2 db를 mysql-mode로 사용해도, ddl-auto : validate가 작동하지 않음.

- 쿠키 sameSite value를 default 값을 Strict로 설정.
- 서브모듈에 환경별로 쿠키 설정을 기입