### PR TITLE
다일리 페이지 미리보기 버그 수정하기

### DIFF
--- a/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageQuerydslImpl.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageQuerydslImpl.java
@@ -24,6 +24,7 @@ public class DailryPageQuerydslImpl implements DailryPageQuerydsl {
                         dailryPage.pageNumber,
                         dailryPage.thumbnail))
                 .from(dailryPage)
+                .where(dailryPage.dailry.id.eq(dailryId))
                 .fetch();
     }
 }

--- a/backend/src/test/java/com/daily/daily/dailrypage/repository/DailryPageQuerydslImplTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/repository/DailryPageQuerydslImplTest.java
@@ -1,0 +1,44 @@
+package com.daily.daily.dailrypage.repository;
+
+import com.daily.daily.dailry.domain.Dailry;
+import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
+import com.daily.daily.testutil.config.JpaTest;
+import com.daily.daily.testutil.generator.DailryGenerator;
+import com.daily.daily.testutil.generator.DailryPageGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DailryPageQuerydslImplTest extends JpaTest {
+
+    @Autowired
+    DailryPageRepository dailryPageRepository;
+
+    @Autowired
+    DailryGenerator dailryGenerator;
+
+    @Autowired
+    DailryPageGenerator dailryPageGenerator;
+
+    @Test
+    @DisplayName("다일리 썸네일 조회 메서드를 테스트한다.")
+    void findThumbnails() {
+        //given
+        Dailry dailry = dailryGenerator.generate();
+        Dailry otherDailry = dailryGenerator.generate();
+
+        dailryPageGenerator.generate(dailry, 3); // (dailry - 페이지수 3개, otherDailry - 페이지 수 0개)
+
+        //when
+        List<DailryPageThumbnailDTO> thumbnails = dailryPageRepository.findThumbnails(dailry.getId());
+        List<DailryPageThumbnailDTO> otherThumbnails = dailryPageRepository.findThumbnails(otherDailry.getId());
+
+        //then
+        assertThat(thumbnails).hasSize(3);
+        assertThat(otherThumbnails).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/daily/daily/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/member/repository/MemberRepositoryTest.java
@@ -5,6 +5,7 @@ import com.daily.daily.member.constant.MemberRole;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.member.validator.Nickname;
 import com.daily.daily.oauth.constant.SocialType;
+import com.daily.daily.testutil.config.JpaTest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,9 +22,7 @@ import java.util.NoSuchElementException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
-@Import(QuerydslConfig.class)
-class MemberRepositoryTest {
+class MemberRepositoryTest extends JpaTest {
 
     static final String TEST_USERNAME = "geonwoo123";
     static final String TEST_NICKNAME = "다일리123";

--- a/backend/src/test/java/com/daily/daily/post/repository/PostLikeRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/post/repository/PostLikeRepositoryTest.java
@@ -4,6 +4,7 @@ import com.daily.daily.common.config.QuerydslConfig;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.domain.PostLike;
+import com.daily.daily.testutil.config.JpaTest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,9 +14,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(QuerydslConfig.class)
-class PostLikeRepositoryTest {
+class PostLikeRepositoryTest extends JpaTest {
 
     @Autowired
     PostLikeRepository likeRepository;

--- a/backend/src/test/java/com/daily/daily/postcomment/repository/PostCommentRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/postcomment/repository/PostCommentRepositoryTest.java
@@ -4,6 +4,7 @@ import com.daily.daily.common.config.QuerydslConfig;
 import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.repository.PostRepository;
 import com.daily.daily.postcomment.domain.PostComment;
+import com.daily.daily.testutil.config.JpaTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,9 +17,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-@Import(QuerydslConfig.class)
-class PostCommentRepositoryTest {
+class PostCommentRepositoryTest extends JpaTest {
 
     @Autowired PostCommentRepository commentRepository;
 

--- a/backend/src/test/java/com/daily/daily/testutil/config/JpaTest.java
+++ b/backend/src/test/java/com/daily/daily/testutil/config/JpaTest.java
@@ -1,0 +1,17 @@
+package com.daily.daily.testutil.config;
+
+import com.daily.daily.common.config.QuerydslConfig;
+import com.daily.daily.testutil.generator.DailryGenerator;
+import com.daily.daily.testutil.generator.DailryPageGenerator;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({
+        QuerydslConfig.class,
+        DailryGenerator.class,
+        DailryPageGenerator.class
+})
+public class JpaTest {
+
+}

--- a/backend/src/test/java/com/daily/daily/testutil/generator/DailryGenerator.java
+++ b/backend/src/test/java/com/daily/daily/testutil/generator/DailryGenerator.java
@@ -1,0 +1,17 @@
+package com.daily.daily.testutil.generator;
+
+import com.daily.daily.dailry.domain.Dailry;
+import com.daily.daily.dailry.repository.DailryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DailryGenerator {
+
+    @Autowired
+    DailryRepository dailryRepository;
+
+    public Dailry generate() {
+        return dailryRepository.save(Dailry.builder().build());
+    }
+}

--- a/backend/src/test/java/com/daily/daily/testutil/generator/DailryPageGenerator.java
+++ b/backend/src/test/java/com/daily/daily/testutil/generator/DailryPageGenerator.java
@@ -1,0 +1,29 @@
+package com.daily.daily.testutil.generator;
+
+import com.daily.daily.dailry.domain.Dailry;
+import com.daily.daily.dailrypage.domain.DailryPage;
+import com.daily.daily.dailrypage.repository.DailryPageRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class DailryPageGenerator {
+
+    @Autowired
+    DailryPageRepository dailryPageRepository;
+
+    public List<DailryPage> generate(Dailry dailry, int count) {
+        List<DailryPage> dailryPages = new ArrayList<>();
+        
+        for (int i = 1; i <= count; i++) {
+            dailryPages.add(dailryPageRepository.save(
+                    DailryPage.builder().dailry(dailry).build())
+            );
+        }
+
+        return dailryPages;
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close: #255 
## 작업 내용
- 다일리 페이지 미리보기 버그 수정
- 테스트코드 작성
- 테스트코드 리팩토링
   - DB를 사용하는 테스트의 경우 데이터를 삽입하는 코드가 중복될 여지가 있을 것 같아서
      TestUtil에 Generator 클래스를 만들어서 데이터를 넣어주는 코드를 작성하였습니다.
   - @DataJpaTest를 작성할 경우 빈 Import 때문에 코드 중복이 발생해서,
      JpaTest 클래스에서 설정을 해주고 기존 @DataJpaTest 를 쓰던 클래스들은 JpaTest를 상속받도록 하였습니다.

## 의논할 거리
## Merge 전에 해야할 작업
## 기타
