### PR TITLE
페이지 생성 API 버그 수정 / 다일리 DELETE 버그 수정 

### DIFF
--- a/backend/src/main/java/com/daily/daily/dailry/service/DailryService.java
+++ b/backend/src/main/java/com/daily/daily/dailry/service/DailryService.java
@@ -7,6 +7,7 @@ import com.daily.daily.dailry.dto.DailryFindDTO;
 import com.daily.daily.dailry.dto.DailryUpdateDTO;
 import com.daily.daily.dailry.exception.DailryNotFoundException;
 import com.daily.daily.dailry.repository.DailryRepository;
+import com.daily.daily.dailrypage.repository.DailryPageRepository;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.member.exception.MemberNotFoundException;
 import com.daily.daily.member.repository.MemberRepository;
@@ -23,6 +24,7 @@ public class DailryService {
 
     private final DailryRepository dailryRepository;
     private final MemberRepository memberRepository;
+    private final DailryPageRepository dailryPageRepository;
 
     public DailryDTO create(Long memberId, DailryUpdateDTO dailryUpdateDTO) {
         Member member = memberRepository.findById(memberId)
@@ -71,6 +73,8 @@ public class DailryService {
         if (!dailry.belongsTo(memberId)) {
             throw new UnauthorizedAccessException();
         }
+
+        dailryPageRepository.deleteByDailry_Id(dailryId);
         dailryRepository.deleteById(dailryId);
     }
 

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageCreateResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageCreateResponseDTO.java
@@ -18,6 +18,7 @@ public class DailryPageCreateResponseDTO {
                 .dailryId(dailryPage.getDailry().getId())
                 .pageId(dailryPage.getId())
                 .background(dailryPage.getBackground())
+                .pageNumber(Long.valueOf(dailryPage.getPageNumber()))
                 .build();
     }
 }

--- a/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageRepository.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageRepository.java
@@ -2,12 +2,10 @@ package com.daily.daily.dailrypage.repository;
 
 import com.daily.daily.dailry.domain.Dailry;
 import com.daily.daily.dailrypage.domain.DailryPage;
-import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface DailryPageRepository extends JpaRepository<DailryPage, Long>, DailryPageQuerydsl {
     int countByDailry(Dailry dailry);
+
+    void deleteByDailry_Id(Long dailryId);
 }

--- a/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydsl.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydsl.java
@@ -7,4 +7,5 @@ import org.springframework.data.domain.Slice;
 public interface PostRepositoryQuerydsl {
 
     Slice<Post> findSlice(Pageable pageable);
+    void deletePostAndRelatedEntities(Long postId);
 }

--- a/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydslImpl.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostRepositoryQuerydslImpl.java
@@ -2,7 +2,6 @@ package com.daily.daily.post.repository;
 
 import com.daily.daily.post.domain.Post;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -13,6 +12,9 @@ import java.util.List;
 
 import static com.daily.daily.member.domain.QMember.member;
 import static com.daily.daily.post.domain.QPost.post;
+import static com.daily.daily.post.domain.QPostHashtag.postHashtag;
+import static com.daily.daily.post.domain.QPostLike.postLike;
+import static com.daily.daily.postcomment.domain.QPostComment.postComment;
 
 @Repository
 @RequiredArgsConstructor
@@ -37,5 +39,17 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
         }
 
         return new SliceImpl<>(posts ,pageable, hasNext);
+    }
+
+    @Override
+    public void deletePostAndRelatedEntities(Long postId) {
+        queryFactory.delete(postLike)
+                .where(postLike.post.id.eq(postId)).execute();
+        queryFactory.delete(postHashtag)
+                .where(postHashtag.post.id.eq(postId)).execute();
+        queryFactory.delete(postComment)
+                .where(postComment.post.id.eq(postId)).execute();
+        queryFactory.delete(post)
+                .where(post.id.eq(postId)).execute();
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/service/PostService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostService.java
@@ -11,7 +11,6 @@ import com.daily.daily.post.dto.PostReadSliceResponseDTO;
 import com.daily.daily.post.dto.PostWriteRequestDTO;
 import com.daily.daily.post.dto.PostWriteResponseDTO;
 import com.daily.daily.post.exception.PostNotFoundException;
-import com.daily.daily.post.repository.PostLikeRepository;
 import com.daily.daily.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -87,7 +86,8 @@ public class PostService {
     public void delete(Long memberId, Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
         validateAuthorityToPost(post, memberId);
-        postRepository.deleteById(postId);
+
+        postRepository.deletePostAndRelatedEntities(postId);
     }
 
 

--- a/backend/src/test/java/com/daily/daily/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/post/repository/PostRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.daily.daily.post.repository;
+
+import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.domain.PostHashtag;
+import com.daily.daily.post.domain.PostLike;
+import com.daily.daily.postcomment.domain.PostComment;
+import com.daily.daily.testutil.config.JpaTest;
+import com.daily.daily.testutil.generator.HashtagGenerator;
+import com.daily.daily.testutil.generator.PostCommentGenerator;
+import com.daily.daily.testutil.generator.PostGenerator;
+import com.daily.daily.testutil.generator.PostLikeGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PostRepositoryTest extends JpaTest {
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    HashtagRepository hashtagRepository;
+
+    @Autowired
+    PostGenerator postGenerator;
+
+    @Autowired
+    PostCommentGenerator postCommentGenerator;
+
+    @Autowired
+    PostLikeGenerator postLikeGenerator;
+
+    @Autowired
+    HashtagGenerator hashtagGenerator;
+
+    @Autowired
+    TestEntityManager testEntityManager;
+    @Test
+    @DisplayName("게시글 삭제 요청이 들어왔을 때, 게시글을 외래키로 참조하는 다른 레코드들도 삭제가 되는지 확인한다.")
+    void deletePostAndRelatedEntities() {
+        //given
+        Post post = postGenerator.generate();
+        List<PostComment> comments = postCommentGenerator.generate(post, 5);// 댓글 5개 생성
+        List<PostLike> likes = postLikeGenerator.generate(post, 3);// 좋아요 3개 생성
+        List<PostHashtag> postHashtags = hashtagGenerator.generate(post, "일반", "대학생", "주말");
+
+        //when
+        postRepository.deletePostAndRelatedEntities(post.getId());
+        testEntityManager.flush();
+        testEntityManager.clear();
+
+        //then
+        //좋아요, 게시글에 달린 해시태그, 댓글, 게시글 << 이 4개 모두 삭제되어야 함.
+        for (PostComment postComment : comments) {      // 댓글 삭제 확인
+            assertThat(testEntityManager.find(PostComment.class, postComment.getId())).isNull();
+        }
+        for (PostLike like : likes) {                   // 좋아요 삭제 확인
+            assertThat(testEntityManager.find(PostLike.class, like.getId())).isNull();
+        }
+        for (PostHashtag postHashtag : postHashtags) {  // 게시글에 연결된 해시태그 삭제 확인
+            assertThat(testEntityManager.find(PostHashtag.class, postHashtag.getId())).isNull();
+        }
+
+        //단 해시태그 데이터 자체는 남아있어야 한다.
+        assertThat(hashtagRepository.findByTagName("일반").isPresent()).isTrue();
+        assertThat(hashtagRepository.findByTagName("대학생").isPresent()).isTrue();
+        assertThat(hashtagRepository.findByTagName("주말").isPresent()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/daily/daily/testutil/config/JpaTest.java
+++ b/backend/src/test/java/com/daily/daily/testutil/config/JpaTest.java
@@ -3,7 +3,11 @@ package com.daily.daily.testutil.config;
 import com.daily.daily.common.config.QuerydslConfig;
 import com.daily.daily.testutil.generator.DailryGenerator;
 import com.daily.daily.testutil.generator.DailryPageGenerator;
+import com.daily.daily.testutil.generator.HashtagGenerator;
 import com.daily.daily.testutil.generator.MemberGenerator;
+import com.daily.daily.testutil.generator.PostCommentGenerator;
+import com.daily.daily.testutil.generator.PostGenerator;
+import com.daily.daily.testutil.generator.PostLikeGenerator;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
@@ -12,7 +16,11 @@ import org.springframework.context.annotation.Import;
         QuerydslConfig.class,
         DailryGenerator.class,
         DailryPageGenerator.class,
-        MemberGenerator.class
+        MemberGenerator.class,
+        PostGenerator.class,
+        PostCommentGenerator.class,
+        PostLikeGenerator.class,
+        HashtagGenerator.class
 })
 public class JpaTest {
 

--- a/backend/src/test/java/com/daily/daily/testutil/generator/HashtagGenerator.java
+++ b/backend/src/test/java/com/daily/daily/testutil/generator/HashtagGenerator.java
@@ -1,0 +1,33 @@
+package com.daily.daily.testutil.generator;
+
+import com.daily.daily.post.domain.Hashtag;
+import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.domain.PostHashtag;
+import com.daily.daily.post.repository.HashtagRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class HashtagGenerator {
+
+    @Autowired
+    HashtagRepository hashtagRepository;
+    public List<PostHashtag> generate(Post post, String... hashtags) {
+        List<PostHashtag> postHashtags = new ArrayList<>();
+
+        for (String hashtag : hashtags) {
+            Hashtag hashtagEntity = Hashtag.of(hashtag);
+            hashtagRepository.save(hashtagEntity);
+
+            PostHashtag postHashtag = PostHashtag.of(post, hashtagEntity);
+
+            post.addPostHashtag(postHashtag);
+            postHashtags.add(postHashtag);
+        }
+
+        return postHashtags;
+    }
+}

--- a/backend/src/test/java/com/daily/daily/testutil/generator/PostCommentGenerator.java
+++ b/backend/src/test/java/com/daily/daily/testutil/generator/PostCommentGenerator.java
@@ -1,0 +1,27 @@
+package com.daily.daily.testutil.generator;
+
+import com.daily.daily.post.domain.Post;
+import com.daily.daily.postcomment.domain.PostComment;
+import com.daily.daily.postcomment.repository.PostCommentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class PostCommentGenerator {
+
+    @Autowired
+    PostCommentRepository postCommentRepository;
+    public List<PostComment> generate(Post post, int count) {
+        List<PostComment> postComments = new ArrayList<>();
+
+        for (int i = 1; i <= count; i++) {
+            PostComment postComment = PostComment.builder().post(post).build();
+            postComments.add(postCommentRepository.save(postComment));
+        }
+
+        return postComments;
+    }
+}

--- a/backend/src/test/java/com/daily/daily/testutil/generator/PostLikeGenerator.java
+++ b/backend/src/test/java/com/daily/daily/testutil/generator/PostLikeGenerator.java
@@ -1,0 +1,29 @@
+package com.daily.daily.testutil.generator;
+
+import com.daily.daily.post.domain.Post;
+import com.daily.daily.post.domain.PostLike;
+import com.daily.daily.post.repository.PostLikeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class PostLikeGenerator {
+
+    @Autowired
+    PostLikeRepository postLikeRepository;
+
+    public List<PostLike> generate(Post post, int count) {
+        List<PostLike> postLikes = new ArrayList<>();
+
+        for (int i = 1; i <= count; i++) {
+            PostLike like = PostLike.builder().post(post).build();
+            postLikes.add(postLikeRepository.save(like));
+        }
+
+        return postLikes;
+    }
+
+}


### PR DESCRIPTION
## 연관 이슈
close: #259 
## 작업 내용
- 페이지 생성 api에서 pageNumber 값으로 null으로 오는 버그 수정
   - DB에는 잘 반영이 되는데 응답 DTO에 pageNumber를 넣어주는 코드가 누락됨
- 다일리 DELETE 가 안되는 버그 수정
   - 외래키 제약조건 때문에, 다일리 페이지를 모두 DELETE 해야 DELETE가 가능함.
## 의논할 거리
## Merge 전에 해야할 작업
## 기타

- 비슷하게 게시글도 같은 이유로 DELETE가 안되는 상황이어서, 해당 부분을 수정하고 테스트코드를 작성함.
- Refresh 토큰 로직을 작성하기 전까지 임시로 dev환경의 액세스토큰 만료 시간을 늘림.