### PR TITLE
다일리 페이지 수정 API 연동

### DIFF
--- a/frontend/src/apis/dailryApi.js
+++ b/frontend/src/apis/dailryApi.js
@@ -40,6 +40,24 @@ export const patchDailry = async (dailryData) => {
   }
 };
 
+export const getPages = async (dailryId) => {
+  try {
+    return await customAxios.get(`/dailry/${dailryId}/pages`);
+  } catch (e) {
+    console.error(e);
+    return e.response.data;
+  }
+};
+
+export const getPage = async (pageId) => {
+  try {
+    return await customAxios.get(`/dailry/pages/${pageId}`);
+  } catch (e) {
+    console.error(e);
+    return e.response.data;
+  }
+};
+
 export const postPage = async (dailryId) => {
   try {
     return await customAxios.post(`dailry/${dailryId}/pages`);
@@ -49,9 +67,13 @@ export const postPage = async (dailryId) => {
   }
 };
 
-export const getPages = async (dailryId) => {
+export const patchPage = async (dailryId, pageData) => {
   try {
-    return await customAxios.get(`/dailry/${dailryId}/pages`);
+    return await customAxios.post(`dailry/pages/${dailryId}/edit`, pageData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
   } catch (e) {
     console.error(e);
     return e.response.data;

--- a/frontend/src/constants/toolbar.js
+++ b/frontend/src/constants/toolbar.js
@@ -30,4 +30,8 @@ export const PAGE_TOOLS = [
     icon: (props) => <DownloadIcon {...props} />,
     type: 'download',
   },
+  {
+    icon: (props) => <DownloadIcon {...props} />,
+    type: 'save',
+  },
 ];

--- a/frontend/src/hooks/useNewDecorateComponent/properties.js
+++ b/frontend/src/hooks/useNewDecorateComponent/properties.js
@@ -9,7 +9,7 @@ export const commonDecorateComponentProperties = {
     x: 0,
     y: 0,
   },
-  rotation: '0deg',
+  rotation: 0,
 };
 
 export const typedDecorateComponentProperties = {

--- a/frontend/src/hooks/useNewDecorateComponent/properties.js
+++ b/frontend/src/hooks/useNewDecorateComponent/properties.js
@@ -2,8 +2,8 @@ export const commonDecorateComponentProperties = {
   id: '',
   order: null,
   size: {
-    width: 'auto',
-    height: 'auto',
+    width: 200,
+    height: 150,
   },
   position: {
     x: 0,

--- a/frontend/src/hooks/usePageData.jsx
+++ b/frontend/src/hooks/usePageData.jsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+
+const usePageData = () => {
+  const formData = new FormData();
+  const [thumbnail, setThumbnail] = useState(null);
+
+  const onUploadFile = (e) => {
+    if (!e.target.files) {
+      return;
+    }
+
+    setThumbnail(e.target.files[0]);
+  };
+
+  const convertDecorateComponentsToBlob = (updatedDecorateComponents) => {
+    const blob = new Blob(
+      [
+        JSON.stringify({
+          background: '무지 테스트',
+          elements: updatedDecorateComponents,
+        }),
+      ],
+      { type: 'application/json' },
+    );
+
+    return blob;
+  };
+
+  const getPageFormData = (updatedDecorateComponents) => {
+    formData.append('thumbnail', thumbnail);
+    formData.append(
+      'dailryPageRequest',
+      convertDecorateComponentsToBlob(updatedDecorateComponents),
+    );
+
+    return formData;
+  };
+
+  return { getPageFormData, onUploadFile };
+};
+
+export default usePageData;

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -9,7 +9,7 @@ import ToolButton from '../../components/da-ily/ToolButton/ToolButton';
 import { DECORATE_TOOLS, PAGE_TOOLS } from '../../constants/toolbar';
 import { LeftArrowIcon, RightArrowIcon } from '../../assets/svg';
 import { useDailryContext } from '../../hooks/useDailryContext';
-import { postPage, getPages } from '../../apis/dailryApi';
+import { postPage, getPages, patchPage } from '../../apis/dailryApi';
 import { DECORATE_TYPE, EDIT_MODE } from '../../constants/decorateComponent';
 import useNewDecorateComponent from '../../hooks/useNewDecorateComponent/useNewDecorateComponent';
 import DecorateWrapper from '../../components/decorate/DecorateWrapper';
@@ -20,6 +20,7 @@ import useEditDecorateComponent from '../../hooks/useEditDecorateComponent';
 import useDecorateComponents from '../../hooks/useDecorateComponents';
 import useUpdatedDecorateComponents from '../../hooks/useUpdatedDecorateComponents';
 import MoveableComponent from '../../components/da-ily/Moveable/Moveable';
+import usePageData from '../../hooks/usePageData';
 
 const DailryPage = () => {
   const pageRef = useRef(null);
@@ -32,8 +33,15 @@ const DailryPage = () => {
   const [pageList, setPageList] = useState(null);
   const { currentDailry, setCurrentDailry } = useDailryContext();
 
-  const { addUpdatedDecorateComponent, modifyUpdatedDecorateComponent } =
-    useUpdatedDecorateComponents();
+  const {
+    updatedDecorateComponents,
+    addUpdatedDecorateComponent,
+    modifyUpdatedDecorateComponent,
+  } = useUpdatedDecorateComponents();
+
+  const { getPageFormData, onUploadFile } = usePageData(
+    updatedDecorateComponents,
+  );
 
   const {
     decorateComponents,
@@ -73,7 +81,7 @@ const DailryPage = () => {
   const { dailryId, pageId } = currentDailry;
 
   useEffect(() => {
-    getPages(dailryId).then((response) => setPageList(response.data.pages));
+    getPages(dailryId).then((response) => setPageList(response.data?.pages));
   }, [dailryId, pageId, showPageModal]);
 
   const toastify = (message) => {
@@ -185,6 +193,7 @@ const DailryPage = () => {
         />
       )}
       <S.CanvasWrapper ref={pageRef} onMouseDown={handleClickPage}>
+        <input type="file" alt="what" onChange={onUploadFile} />
         {decorateComponents?.map((element, index) => {
           const canEdit =
             editMode === EDIT_MODE.TYPE_CONTENT &&
@@ -263,7 +272,7 @@ const DailryPage = () => {
             );
           })}
           {PAGE_TOOLS.map(({ icon, type }, index) => {
-            const onSelect = (t) => {
+            const onSelect = async (t) => {
               if (newDecorateComponent) {
                 completeCreateNewDecorateComponent();
               }
@@ -283,6 +292,10 @@ const DailryPage = () => {
               }
               if (t === 'download') {
                 handleDownloadClick();
+              }
+              if (t === 'save') {
+                const formData = getPageFormData(updatedDecorateComponents);
+                await patchPage(48, formData);
               }
             };
             return (

--- a/frontend/src/pages/DailryPage/DailryPage.styled.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.styled.jsx
@@ -35,8 +35,8 @@ export const ElementStyle = ({ position, order, size, canEdit }) => {
     position: 'absolute',
     left: `${position.x}px`,
     top: `${position.y}px`,
-    width: size.width,
-    height: size.height,
+    width: `${size.width}px`,
+    height: `${size.height}px`,
     zIndex: order,
     border: canEdit ? `2px dashed #74ABD9` : '',
   };


### PR DESCRIPTION
## 연관 이슈
close: #262 
## 작업 내용
* 다일리 페이지 수정 API `patchPage` 함수 추가
* `usePageData` 커스텀 훅 추가
   - `multipart/form-data` 형식의 데이터로 변환하는 `convertDecorateComponentsToBlob` 함수 추가
   - 썸네일 데이터 에 해당하는 `thumbnail` 상태 추가
* `PAGE_TOOLS` 상수에 save 타입 추가
   - 해당 타입 버튼 클릭 시 수정 API 호출 하도록 조건 추가
* 꾸미기 컴포넌트 공통 속성 중 size 타입 변경
* 꾸미기 컴포넌트 공통 속성 rotation 초기 값 수정
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
