### PR TITLE
다일리 페이지 단건 조회 API 연동 및 꾸미기 컴포넌트 데이터 관련 버그 수정, 개선

### DIFF
--- a/frontend/src/components/common/Navigation/DailryNavigation.jsx
+++ b/frontend/src/components/common/Navigation/DailryNavigation.jsx
@@ -32,7 +32,6 @@ const DailryNavigation = () => {
         setCurrentDailry({
           ...currentDailry,
           dailryId: updatedDailryItems[0].dailryId,
-          pageNumber: null,
         });
       }
     })();

--- a/frontend/src/components/decorate/Drawing/useDrawInstance.jsx
+++ b/frontend/src/components/decorate/Drawing/useDrawInstance.jsx
@@ -8,23 +8,27 @@ const useDrawInstance = (canvas, typeContent) => {
   const [drawInstance, setDrawInstance] = useState(undefined);
 
   useEffect(() => {
-    const { ctx } = createCtx(canvas.current);
+    if (canvas.current && typeContent?.base64) {
+      const { ctx } = createCtx(canvas.current);
 
-    const img = new Image();
-
-    if (typeContent) {
+      const img = new Image();
       img.src = typeContent.base64;
 
       img.onload = () => {
-        if (ctx) {
+        if (ctx && canvas.current) {
           ctx.globalCompositeOperation = 'source-over';
-          ctx.drawImage(img, 0, 0, canvas.current.width, canvas.current.height);
+          ctx.drawImage(
+            img,
+            0,
+            0,
+            canvas.current?.width,
+            canvas.current?.height,
+          );
         }
       };
+      setDrawInstance(new Draw(canvas.current, ctx));
     }
-
-    setDrawInstance(new Draw(canvas.current, ctx));
-  }, [contentsLoaded]);
+  }, [contentsLoaded, canvas, typeContent?.base64]);
 
   return { drawInstance };
 };

--- a/frontend/src/components/decorate/Drawing/useDrawInstance.jsx
+++ b/frontend/src/components/decorate/Drawing/useDrawInstance.jsx
@@ -8,10 +8,10 @@ const useDrawInstance = (canvas, typeContent) => {
   const [drawInstance, setDrawInstance] = useState(undefined);
 
   useEffect(() => {
-    if (canvas.current && typeContent?.base64) {
-      const { ctx } = createCtx(canvas.current);
+    const { ctx } = createCtx(canvas.current);
 
-      const img = new Image();
+    const img = new Image();
+    if (canvas.current && typeContent?.base64) {
       img.src = typeContent.base64;
 
       img.onload = () => {
@@ -26,8 +26,8 @@ const useDrawInstance = (canvas, typeContent) => {
           );
         }
       };
-      setDrawInstance(new Draw(canvas.current, ctx));
     }
+    setDrawInstance(new Draw(canvas.current, ctx));
   }, [contentsLoaded, canvas, typeContent?.base64]);
 
   return { drawInstance };

--- a/frontend/src/components/decorate/TextBox/TextBox.jsx
+++ b/frontend/src/components/decorate/TextBox/TextBox.jsx
@@ -1,10 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import * as S from './TextBox.styled';
+import useDebounce from '../../../hooks/useDebounce';
 
 const TextBox = (props) => {
   const { typeContent, setTypeContent } = props;
+
   const [text, setText] = useState('');
+  const debouncedText = useDebounce(text, 500);
   const textRef = useRef(null);
   const [height, setHeight] = useState(typeContent?.current?.scrollHeight);
 
@@ -16,7 +19,7 @@ const TextBox = (props) => {
     if (typeContent?.text.length > 0) {
       setText(typeContent.text);
     }
-  }, [typeContent]);
+  }, []);
 
   return (
     <S.TextArea
@@ -25,9 +28,7 @@ const TextBox = (props) => {
       height={height}
       onChange={(e) => {
         setText(e.target.value);
-        setTimeout(() => {
-          setTypeContent({ text });
-        }, 500);
+        setTypeContent({ text: debouncedText });
       }}
     />
   );

--- a/frontend/src/components/decorate/TextBox/TextBox.jsx
+++ b/frontend/src/components/decorate/TextBox/TextBox.jsx
@@ -4,6 +4,7 @@ import * as S from './TextBox.styled';
 
 const TextBox = (props) => {
   const { typeContent, setTypeContent } = props;
+  const [text, setText] = useState('');
   const textRef = useRef(null);
   const [height, setHeight] = useState(typeContent?.current?.scrollHeight);
 
@@ -11,12 +12,23 @@ const TextBox = (props) => {
     setHeight(textRef?.current.scrollHeight);
   }, [textRef?.current?.scrollHeight]);
 
+  useEffect(() => {
+    if (typeContent?.text.length > 0) {
+      setText(typeContent.text);
+    }
+  }, [typeContent]);
+
   return (
     <S.TextArea
       ref={textRef}
-      value={typeContent}
+      value={text}
       height={height}
-      onChange={(e) => setTypeContent(e.target.value)}
+      onChange={(e) => {
+        setText(e.target.value);
+        setTimeout(() => {
+          setTypeContent({ text });
+        }, 500);
+      }}
     />
   );
 };

--- a/frontend/src/hooks/useDebounce.jsx
+++ b/frontend/src/hooks/useDebounce.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+const useDebounce = (value, delay) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      console.log(value);
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/frontend/src/hooks/useDecorateComponents.jsx
+++ b/frontend/src/hooks/useDecorateComponents.jsx
@@ -19,6 +19,7 @@ const useDecorateComponents = () => {
 
   return {
     decorateComponents,
+    setDecorateComponents,
     addNewDecorateComponent,
     modifyDecorateComponent,
   };

--- a/frontend/src/hooks/useNewDecorateComponent/properties.js
+++ b/frontend/src/hooks/useNewDecorateComponent/properties.js
@@ -9,7 +9,7 @@ export const commonDecorateComponentProperties = {
     x: 0,
     y: 0,
   },
-  rotation: 0,
+  rotation: '0',
 };
 
 export const typedDecorateComponentProperties = {

--- a/frontend/src/hooks/useUpdatedDecorateComponents.jsx
+++ b/frontend/src/hooks/useUpdatedDecorateComponents.jsx
@@ -10,6 +10,14 @@ const useUpdatedDecorateComponents = () => {
   };
 
   const modifyUpdatedDecorateComponent = (updatedDecorateComponent) => {
+    if (
+      !updatedDecorateComponents.some(
+        (id) => id === updatedDecorateComponent.id,
+      )
+    ) {
+      addUpdatedDecorateComponent(updatedDecorateComponent);
+      return;
+    }
     setUpdatedDecorateComponents((prev) =>
       prev.map((decorateComponent) => {
         return decorateComponent.id === updatedDecorateComponent.id

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -10,7 +10,7 @@ import ToolButton from '../../components/da-ily/ToolButton/ToolButton';
 import { DECORATE_TOOLS, PAGE_TOOLS } from '../../constants/toolbar';
 import { LeftArrowIcon, RightArrowIcon } from '../../assets/svg';
 import { useDailryContext } from '../../hooks/useDailryContext';
-import { postPage, getPages, patchPage } from '../../apis/dailryApi';
+import { postPage, getPages, patchPage, getPage } from '../../apis/dailryApi';
 import { DECORATE_TYPE, EDIT_MODE } from '../../constants/decorateComponent';
 import useNewDecorateComponent from '../../hooks/useNewDecorateComponent/useNewDecorateComponent';
 import DecorateWrapper from '../../components/decorate/DecorateWrapper';
@@ -48,6 +48,7 @@ const DailryPage = () => {
 
   const {
     decorateComponents,
+    setDecorateComponents,
     addNewDecorateComponent,
     modifyDecorateComponent,
   } = useDecorateComponents();
@@ -81,26 +82,40 @@ const DailryPage = () => {
 
   const isMoveable = () => target && editMode === EDIT_MODE.COMMON_PROPERTY;
 
-  const { dailryId, pageId, pageNumber } = currentDailry;
+  const { dailryId, pageId, pageIds, pageNumber } = currentDailry;
 
   useEffect(() => {
     (async () => {
-      const response = await getPages(dailryId);
-      const { status, data } = response;
+      const { status, data } = await getPages(dailryId);
+
       if (status === 200 && data.pages.length !== 0) {
         const { pages } = data;
-        const pageIds = pages.map((page) => page.pageId);
-        setPageList(pages);
+        const pageIdList = pages.map((page) => page.pageId);
+        setPageList(pageIdList);
+
         setCurrentDailry({
           ...currentDailry,
-          pageNumber: pageNumber ?? 1,
-          pageIds,
+          pageIds: pageIdList,
+          pageNumber: pageIds ? 1 : null,
         });
+
         return setHavePage(true);
       }
+
       return setHavePage(false);
     })();
-  }, [dailryId, pageNumber, showPageModal]);
+  }, [dailryId]);
+
+  useEffect(() => {
+    (async () => {
+      setDecorateComponents([]);
+      const page = await getPage(pageIds[pageNumber - 1]);
+
+      if (page.data?.elements.length > 0) {
+        setDecorateComponents(page.data?.elements);
+      }
+    })();
+  }, [pageIds, pageNumber]);
 
   const toastify = (message) => {
     toast(message, {

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -329,7 +329,6 @@ const DailryPage = () => {
               }, 150);
               if (t === 'add') {
                 const response = await postPage(dailryId);
-                console.log(response);
                 setCurrentDailry({
                   ...currentDailry,
                   pageId: response.data.pageId,
@@ -341,7 +340,7 @@ const DailryPage = () => {
               }
               if (t === 'save') {
                 const formData = getPageFormData(updatedDecorateComponents);
-                await patchPage(48, formData);
+                await patchPage(pageIds[pageNumber - 1], formData);
               }
             };
             return (


### PR DESCRIPTION
## 연관 이슈
close: #267 
## 작업 내용
* 다일리 페이지 단건 조회 API 연동
   * `DailryNavigation` 에서 `pageNumber` 를 제어하지 않도록 수정  
   * 첫 렌더링 시 에만 `getPages` 호출하도록 수정
   * `pageNumber` 값이 변경될 때, `getPage` 호출하도록 수정 `useEffect` 의존값 설정
      - `pageNumber` 를 `pageIds` 의 인덱스로 `pageId` 검색 하여 호출 파라미터로 전송
* 꾸미기 컴포넌트 데이터 관련 버그 수정, 개선
   - 공통속성 rotation 초기 값 수정
   - `updatedDecorateComponents` 배열에 해당 꾸미기 컴포넌트가 있으면 수정, 없으면 삽입 하도록 수정
   - TextBox 입력 데이터 와 typeContent 에 삽입할 데이터 분리
      - `text` 라는 상태 추가 하여, `onChange` 이벤트가 실행될때 해당 상태의 값 갱신 하고, 일정시간 이후 `typeContent` 값 을 삽입하는 함수를 호출
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
* 클라이언트 에서 `pageNumber` 가 고유한 값으로 지속될 수 있는지, 확인 필요
