### PR TITLE
인기 다일리 페이지 게시글 기능 추가

### DIFF
--- a/backend/src/docs/asciidoc/api-document.adoc
+++ b/backend/src/docs/asciidoc/api-document.adoc
@@ -403,6 +403,20 @@ include::{snippets}/게시글 삭제/path-parameters.adoc[]
 include::{snippets}/게시글 삭제/http-response.adoc[]
 
 
+== 인기 게시글
+
+=== 인기게시글 여러건 조회
+
+==== 요청
+
+include::{snippets}/인기 게시글 여러건 조회/http-request.adoc[]
+include::{snippets}/인기 게시글 여러건 조회/query-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/인기 게시글 여러건 조회/http-response.adoc[]
+include::{snippets}/인기 게시글 여러건 조회/response-fields.adoc[]
+
 == 게시글 좋아요
 
 === 좋아요 증가

--- a/backend/src/main/java/com/daily/daily/auth/config/CorsConfig.java
+++ b/backend/src/main/java/com/daily/daily/auth/config/CorsConfig.java
@@ -17,7 +17,9 @@ public class CorsConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(List.of("http://127.0.0.1:3000", "http://localhost:3000", "https://localhost:3000", "https://da-ily.site"));
+        configuration.setAllowedOrigins(List.of("http://127.0.0.1:3000", "http://localhost:3000",
+                "https://localhost:3000", "https://da-ily.site",
+                "https://dailry-3yqoncc16-hangooksaram.vercel.app"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("*"));

--- a/backend/src/main/java/com/daily/daily/common/config/Business/BusinessConfig.java
+++ b/backend/src/main/java/com/daily/daily/common/config/Business/BusinessConfig.java
@@ -1,4 +1,4 @@
-package com.daily.daily.common.config;
+package com.daily.daily.common.config.Business;
 
 public class BusinessConfig {
     public static final int HOT_POST_LIKE_THRESHOLD = 15; // 인기게시글로 올라가는 좋아요 갯수

--- a/backend/src/main/java/com/daily/daily/common/config/Business/BusinessConfig.java
+++ b/backend/src/main/java/com/daily/daily/common/config/Business/BusinessConfig.java
@@ -1,6 +1,6 @@
 package com.daily.daily.common.config.Business;
 
 public class BusinessConfig {
-    public static final int HOT_POST_LIKE_THRESHOLD = 15; // 인기게시글로 올라가는 좋아요 갯수
+    public static final int HOT_POST_LIKE_THRESHOLD = 15; // 인기게시글로 올라가는 좋아요 갯수 기준
     public static final long HOT_POST_CREATED_TIME_CONDITION = 7; // 7일이내에 생성된 게시글만 인기게시글로 올라갈 수 있다.
 }

--- a/backend/src/main/java/com/daily/daily/common/config/BusinessConfig.java
+++ b/backend/src/main/java/com/daily/daily/common/config/BusinessConfig.java
@@ -1,0 +1,6 @@
+package com.daily.daily.common.config;
+
+public class BusinessConfig {
+    public static final int HOT_POST_LIKE_THRESHOLD = 15; // 인기게시글로 올라가는 좋아요 갯수
+    public static final long HOT_POST_CREATED_TIME_CONDITION = 7; // 7일이내에 생성된 게시글만 인기게시글로 올라갈 수 있다.
+}

--- a/backend/src/main/java/com/daily/daily/post/controller/HotPostController.java
+++ b/backend/src/main/java/com/daily/daily/post/controller/HotPostController.java
@@ -1,0 +1,21 @@
+package com.daily.daily.post.controller;
+
+import com.daily.daily.post.dto.HotPostReadSliceResponseDTO;
+import com.daily.daily.post.service.HotPostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/hotPosts")
+@RequiredArgsConstructor
+public class HotPostController {
+
+    private final HotPostService hotPostService;
+    @GetMapping
+    public HotPostReadSliceResponseDTO readSlice(Pageable pageable) {
+        return hotPostService.findSlice(pageable);
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/domain/HotPost.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/HotPost.java
@@ -1,0 +1,31 @@
+package com.daily.daily.post.domain;
+
+
+import com.daily.daily.common.domain.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class HotPost extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @OneToOne(fetch = FetchType.LAZY)
+    private Post post;
+
+    protected HotPost() {
+    }
+
+    public static HotPost of(Post post) {
+        return new HotPost(post);
+    }
+    private HotPost(Post post) {
+        this.post = post;
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -40,7 +40,7 @@ public class Post extends BaseTimeEntity {
     private long likeCount;
     private boolean isHotPost = false;
     @Version
-    private Long version;
+    private long version;
 
     private static final int hotPostThreadHold = 15;
 

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.daily.daily.common.config.BusinessConfig.HOT_POST_LIKE_THRESHOLD;
-import static com.daily.daily.common.config.BusinessConfig.HOT_POST_CREATED_TIME_CONDITION;
+import static com.daily.daily.common.config.Business.BusinessConfig.HOT_POST_LIKE_THRESHOLD;
+import static com.daily.daily.common.config.Business.BusinessConfig.HOT_POST_CREATED_TIME_CONDITION;
 
 
 @Entity

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -14,7 +14,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Version;
 import lombok.Builder;
 import lombok.Getter;
-import org.hibernate.annotations.SQLDelete;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,8 +23,6 @@ import java.util.stream.Collectors;
 @Entity
 @Getter
 public class Post extends BaseTimeEntity {
-
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -41,9 +38,11 @@ public class Post extends BaseTimeEntity {
     private List<PostHashtag> postHashtags = new ArrayList<>();
 
     private long likeCount;
-
+    private boolean isHotPost = false;
     @Version
     private Long version;
+
+    private static final int hotPostThreadHold = 15;
 
     @Builder
     public Post(String content, String pageImage, Member postWriter) {
@@ -96,5 +95,13 @@ public class Post extends BaseTimeEntity {
 
     public void decreaseLikeCount() {
         likeCount--;
+    }
+
+    public boolean satisfyHotPostCondition() {
+        return likeCount >= hotPostThreadHold;
+    }
+
+    public void makeHotPost() {
+        isHotPost = true;
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -97,8 +97,8 @@ public class Post extends BaseTimeEntity {
         likeCount--;
     }
 
-    public boolean satisfyHotPostCondition() {
-        return likeCount >= hotPostThreadHold;
+    public boolean satisfyHotPostCondition() {return
+            likeCount >= hotPostThreadHold;
     }
 
     public void makeHotPost() {

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -15,9 +15,13 @@ import jakarta.persistence.Version;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.daily.daily.common.config.BusinessConfig.HOT_POST_LIKE_THRESHOLD;
+import static com.daily.daily.common.config.BusinessConfig.HOT_POST_CREATED_TIME_CONDITION;
 
 
 @Entity
@@ -41,8 +45,6 @@ public class Post extends BaseTimeEntity {
     private boolean isHotPost = false;
     @Version
     private long version;
-
-    private static final int hotPostThreadHold = 15;
 
     @Builder
     public Post(String content, String pageImage, Member postWriter) {
@@ -97,8 +99,8 @@ public class Post extends BaseTimeEntity {
         likeCount--;
     }
 
-    public boolean satisfyHotPostCondition() {return
-            likeCount >= hotPostThreadHold;
+    public boolean satisfyHotPostCondition() {
+        return likeCount >= HOT_POST_LIKE_THRESHOLD && getCreatedTime().isAfter(LocalDateTime.now().minusDays(HOT_POST_CREATED_TIME_CONDITION));
     }
 
     public void makeHotPost() {

--- a/backend/src/main/java/com/daily/daily/post/domain/Post.java
+++ b/backend/src/main/java/com/daily/daily/post/domain/Post.java
@@ -100,7 +100,8 @@ public class Post extends BaseTimeEntity {
     }
 
     public boolean satisfyHotPostCondition() {
-        return likeCount >= HOT_POST_LIKE_THRESHOLD && getCreatedTime().isAfter(LocalDateTime.now().minusDays(HOT_POST_CREATED_TIME_CONDITION));
+        return likeCount >= HOT_POST_LIKE_THRESHOLD
+                && getCreatedTime().isAfter(LocalDateTime.now().minusDays(HOT_POST_CREATED_TIME_CONDITION));
     }
 
     public void makeHotPost() {

--- a/backend/src/main/java/com/daily/daily/post/dto/HotPostReadResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/HotPostReadResponseDTO.java
@@ -5,6 +5,7 @@ import com.daily.daily.post.domain.Post;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -13,6 +14,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
+@EqualsAndHashCode
 public class HotPostReadResponseDTO{
     //기존 PostReadDTO
     private Long postId;

--- a/backend/src/main/java/com/daily/daily/post/dto/HotPostReadResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/HotPostReadResponseDTO.java
@@ -1,0 +1,44 @@
+package com.daily.daily.post.dto;
+
+import com.daily.daily.post.domain.HotPost;
+import com.daily.daily.post.domain.Post;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class HotPostReadResponseDTO{
+    //기존 PostReadDTO
+    private Long postId;
+    private String content;
+    private String pageImage;
+    private Long writerId;
+    private String writerNickname;
+    private List<String> hashtags;
+    private Long likeCount;
+    private LocalDateTime createdTime;
+
+    //추가된 항목
+    private LocalDateTime hotPostCreatedTime;
+    public static HotPostReadResponseDTO from(HotPost hotPost) {
+        Post post = hotPost.getPost();
+
+        return HotPostReadResponseDTO.builder()
+                .postId(post.getId())
+                .content(post.getContent())
+                .pageImage(post.getPageImage())
+                .writerId(post.getWriterId())
+                .writerNickname(post.getWriterNickname())
+                .hashtags(post.getTagNames())
+                .createdTime(post.getCreatedTime())
+                .likeCount(post.getLikeCount())
+                .hotPostCreatedTime(hotPost.getCreatedTime())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/dto/HotPostReadSliceResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/HotPostReadSliceResponseDTO.java
@@ -3,6 +3,7 @@ package com.daily.daily.post.dto;
 import com.daily.daily.post.domain.HotPost;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -14,6 +15,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @Getter
 @Builder
+@EqualsAndHashCode
 public class HotPostReadSliceResponseDTO {
     private Integer presentPage;
     private Boolean hasNext;
@@ -33,6 +35,4 @@ public class HotPostReadSliceResponseDTO {
                 .map(HotPostReadResponseDTO::from)
                 .collect(Collectors.toList());
     }
-
-
 }

--- a/backend/src/main/java/com/daily/daily/post/dto/HotPostReadSliceResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/HotPostReadSliceResponseDTO.java
@@ -1,0 +1,38 @@
+package com.daily.daily.post.dto;
+
+import com.daily.daily.post.domain.HotPost;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class HotPostReadSliceResponseDTO {
+    private Integer presentPage;
+    private Boolean hasNext;
+    private List<HotPostReadResponseDTO> hotPosts;
+    public static HotPostReadSliceResponseDTO from(Slice<HotPost> hotPosts) {
+        List<HotPostReadResponseDTO> hotPostReadResponseDTOS = convertToDTO(hotPosts.getContent());
+
+        return HotPostReadSliceResponseDTO.builder()
+                .presentPage(hotPosts.getNumber())
+                .hasNext(hotPosts.hasNext())
+                .hotPosts(hotPostReadResponseDTOS)
+                .build();
+    }
+
+    private static List<HotPostReadResponseDTO> convertToDTO(List<HotPost> hotPosts) {
+        return hotPosts.stream()
+                .map(HotPostReadResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+
+
+}

--- a/backend/src/main/java/com/daily/daily/post/dto/PostReadSliceResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/post/dto/PostReadSliceResponseDTO.java
@@ -32,16 +32,7 @@ public class PostReadSliceResponseDTO {
 
     private static List<PostReadResponseDTO> convertToDTO(List<Post> posts) {
         return posts.stream()
-                .map(post -> PostReadResponseDTO.builder()
-                        .postId(post.getId())
-                        .content(post.getContent())
-                        .pageImage(post.getPageImage())
-                        .writerId(post.getWriterId())
-                        .writerNickname(post.getWriterNickname())
-                        .hashtags(post.getTagNames())
-                        .createdTime(post.getCreatedTime())
-                        .likeCount(post.getLikeCount())
-                        .build()
-                ).collect(Collectors.toList());
+                .map(PostReadResponseDTO::from)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/repository/HotPostRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/HotPostRepository.java
@@ -3,5 +3,5 @@ package com.daily.daily.post.repository;
 import com.daily.daily.post.domain.HotPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HotPostRepository extends JpaRepository<HotPost, Long> {
+public interface HotPostRepository extends JpaRepository<HotPost, Long>, HotPostRepositoryQuerydsl {
 }

--- a/backend/src/main/java/com/daily/daily/post/repository/HotPostRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/HotPostRepository.java
@@ -1,0 +1,7 @@
+package com.daily.daily.post.repository;
+
+import com.daily.daily.post.domain.HotPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HotPostRepository extends JpaRepository<HotPost, Long> {
+}

--- a/backend/src/main/java/com/daily/daily/post/repository/HotPostRepositoryQuerydsl.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/HotPostRepositoryQuerydsl.java
@@ -1,0 +1,10 @@
+package com.daily.daily.post.repository;
+
+import com.daily.daily.post.domain.HotPost;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface HotPostRepositoryQuerydsl {
+    Slice<HotPost> findSlice(Pageable pageable);
+
+}

--- a/backend/src/main/java/com/daily/daily/post/repository/HotPostRepositoryQuerydslImpl.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/HotPostRepositoryQuerydslImpl.java
@@ -1,0 +1,41 @@
+package com.daily.daily.post.repository;
+
+import com.daily.daily.post.domain.HotPost;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.daily.daily.member.domain.QMember.member;
+import static com.daily.daily.post.domain.QHotPost.hotPost;
+import static com.daily.daily.post.domain.QPost.post;
+
+@Repository
+@RequiredArgsConstructor
+public class HotPostRepositoryQuerydslImpl implements HotPostRepositoryQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<HotPost> findSlice(Pageable pageable) {
+        List<HotPost> hotPosts = queryFactory.selectFrom(hotPost)
+                .leftJoin(hotPost.post, post).fetchJoin()
+                .leftJoin(hotPost.post.postWriter, member).fetchJoin()
+                .orderBy(hotPost.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = hotPosts.size() > pageable.getPageSize();
+
+        if (hasNext) {
+            hotPosts.remove(hotPosts.size() - 1);
+        }
+
+        return new SliceImpl<>(hotPosts, pageable, hasNext);
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/repository/PostLikeRepository.java
+++ b/backend/src/main/java/com/daily/daily/post/repository/PostLikeRepository.java
@@ -1,6 +1,5 @@
 package com.daily.daily.post.repository;
 
-import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.domain.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,7 +10,5 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     @Query("select pl from PostLike pl where pl.post.id = :postId and pl.member.id = :memberId")
     Optional<PostLike> findBy(Long memberId, Long postId);
-
-    Long countByPost(Post post);
 }
 

--- a/backend/src/main/java/com/daily/daily/post/service/HotPostService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/HotPostService.java
@@ -1,0 +1,23 @@
+package com.daily.daily.post.service;
+
+import com.daily.daily.post.domain.HotPost;
+import com.daily.daily.post.dto.HotPostReadSliceResponseDTO;
+import com.daily.daily.post.repository.HotPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HotPostService {
+
+    private final HotPostRepository hotPostRepository;
+
+    public HotPostReadSliceResponseDTO findSlice(Pageable pageable) {
+        Slice<HotPost> hotPosts = hotPostRepository.findSlice(pageable);
+        return null;
+    }
+}

--- a/backend/src/main/java/com/daily/daily/post/service/HotPostService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/HotPostService.java
@@ -18,6 +18,6 @@ public class HotPostService {
 
     public HotPostReadSliceResponseDTO findSlice(Pageable pageable) {
         Slice<HotPost> hotPosts = hotPostRepository.findSlice(pageable);
-        return null;
+        return HotPostReadSliceResponseDTO.from(hotPosts);
     }
 }

--- a/backend/src/main/java/com/daily/daily/post/service/PostLikeFacade.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostLikeFacade.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 
-//todo : 낙관적 락 실패시 retry하는 로직은, 여러곳에서 중복되어 사용할 수 있는 횡단 관심사 (cross-cutting concern) 이다. 추후에 AOP를 이용해서 리팩토링을 해야한다.
+//todo : 낙관적 락 실패시 retry 하는 로직은, 여러곳에서 중복되어 사용할 수 있는 횡단 관심사 (cross-cutting concern) 이다. 추후에 AOP를 이용해서 리팩토링을 해야한다.
 public class PostLikeFacade {
     private final PostLikeService postLikeService;
 

--- a/backend/src/main/resources/db/migration/V202403041352__addHotPostTable.sql
+++ b/backend/src/main/resources/db/migration/V202403041352__addHotPostTable.sql
@@ -1,7 +1,9 @@
 CREATE TABLE hot_post (
       id bigint primary key auto_increment,
-      post_id bigint,
+      post_id bigint unique,
       created_time datetime,
       updated_time datetime,
       FOREIGN KEY (post_id) REFERENCES post(id)
 );
+
+ALTER TABLE post ADD COLUMN is_hot_post boolean;

--- a/backend/src/main/resources/db/migration/V202403041352__addHotPostTable.sql
+++ b/backend/src/main/resources/db/migration/V202403041352__addHotPostTable.sql
@@ -1,0 +1,7 @@
+CREATE TABLE hot_post (
+      id bigint primary key auto_increment,
+      post_id bigint,
+      created_time datetime,
+      updated_time datetime,
+      FOREIGN KEY (post_id) REFERENCES post(id)
+);

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -497,6 +497,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_게시글_삭제">게시글 삭제</a></li>
 </ul>
 </li>
+<li><a href="#_인기_게시글">인기 게시글</a>
+<ul class="sectlevel2">
+<li><a href="#_인기게시글_여러건_조회">인기게시글 여러건 조회</a></li>
+</ul>
+</li>
 <li><a href="#_게시글_좋아요">게시글 좋아요</a>
 <ul class="sectlevel2">
 <li><a href="#_좋아요_증가">좋아요 증가</a></li>
@@ -593,9 +598,9 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA4NTgxOTMzfQ.vil93Hb4UtjMN1VBCWBOBBgrPu8Oo8vdusDXXUmIMpBfNPpoQjcMeGKFQXFYtKn62WHAm8fJE9E9ixWAjG6Q-w; Path=/; Domain=da-ily.site; Secure; HttpOnly; SameSite=None
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwODU3ODMzMywiZXhwIjoxNzA5Nzg3OTMzfQ.4gVF81dA5qc-Z_TPrW7HPODhu4-Qlv6eFycXyN_qzM5a7ciowOiOPcE7xbah9daH5es7Jheue_nHvHsBeH_qSA; Path=/; Domain=da-ily.site; Secure; HttpOnly; SameSite=None
-Content-Type: application/json;charset=UTF-8
+Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5OTUyNzkzfQ.pwM-qN2YQLZGRx0n4w2NEzqipZewo2Fyl65W10wfys41SdJsTntn6fq0Ln4RqqVBgZ6jgRnAJHQA0Qe31nVsqQ; Path=/; Domain=localhost; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwOTcxODU1OSwiZXhwIjoxOTQzOTUyNzkzfQ.1hQlHBI1aW83FA9NIzofM5-MkFVfjf69gXCZGVcHTKfMzP4fiBkBkAwsn-m_T2wcqZaO8zs5sFp9f-4P_6VrNg; Path=/; Domain=localhost; Secure; HttpOnly; SameSite=None
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -613,8 +618,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/logout HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDg1ODE5MzF9.LW1mP8vG2zGLLI0pC7GYiVunhZcxG4nr3Upe2tVfXvNY1xis7atQB8Zb6Ub_M7QGDRljdIn-nj1NfipcwBVB2A
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA4NTc4MzMxLCJleHAiOjE3MDk3ODc5MzF9.FBd6wpmGlN7oQShQyZ5OnogXqP--gkH97rbDIX9V9KYGaqzQtDGVkEAVE-jJxYOAC31bHJUNJ8fmcstBGQPdBg</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDk5NTI3OTJ9.NwogX239UTsQ-tcXXFFMtCu6z7eXoq6rW3VE03BAi2PUiUuyaaXzAGv9HR1OY5ZFLSidssvZ9koWA7ly5SK43w
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA5NzE4NTU4LCJleHAiOjE5NDM5NTI3OTJ9._16-kRlFpSe1BuPyE4mvfHIPLA27HNMx7aKEb05mbpXLNZOAU68aVdjcAVBoEYmv52_Am_7LMro1NkUZqJ5txA</code></pre>
 </div>
 </div>
 </div>
@@ -623,9 +628,9 @@ Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA4NTc4Mz
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: AccessToken=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT
-Set-Cookie: RefreshToken=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT
-Content-Type: application/json;charset=UTF-8
+Set-Cookie: AccessToken=; Path=/; Domain=localhost; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly
+Set-Cookie: RefreshToken=; Path=/; Domain=localhost; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -643,8 +648,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/token HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo0LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDg1ODE5MzJ9.cd_mzCtxWeodUDcMgLeBew1g6azpRjS13hsfambAYs9CnVVT3PWNn_VoGtGrL50O_rmLquWpoEv37_PQGCUIFQ
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzA4NTc4MzMyLCJleHAiOjE3MDk3ODc5MzJ9.ojsJHZXTqPYuCuhoSQPa4-wMHnBmdNL5yo2GTjnM8fDEWCkKKVEw6aRxPwzdFMwf49I8ttYxBTLFopkapvUcUQ</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo0LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDk5NTI3OTJ9.A-xKJk9_Lx_2ZXi_3KGzMtrmccQm2_u5ERzp0gIHU4aKORKHPq1rQ0wJixmcjGyUEpBogsgzVpMzhPp1IF3H5A
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzA5NzE4NTU4LCJleHAiOjE5NDM5NTI3OTJ9.T--T2t5bEXf9mIJcX6xnjVwKxfyXRFDCYYGzB0z5_hMcGoznwmMbvYn5x2JSla5Phq16s65jfBnUkCr5NI9q5g</code></pre>
 </div>
 </div>
 </div>
@@ -653,7 +658,7 @@ Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzA4NTc4Mz
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -756,7 +761,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "memberId" : 1,
@@ -825,7 +830,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "memberId" : 1,
@@ -915,7 +920,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "duplicated" : true
@@ -984,7 +989,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "duplicated" : true
@@ -1061,7 +1066,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "memberId" : 1,
@@ -1166,7 +1171,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -1220,7 +1225,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -1281,7 +1286,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -1335,7 +1340,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -1396,7 +1401,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -1457,7 +1462,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -1483,7 +1488,7 @@ Content-Type: application/json;charset=UTF-8</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -1572,7 +1577,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "dailryId" : 16,
@@ -1656,7 +1661,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "dailryId" : 16,
@@ -1725,7 +1730,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "dailryId" : 16,
@@ -1781,7 +1786,7 @@ Content-Type: application/json;charset=UTF-8</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 [ {
   "dailryId" : 16,
@@ -1853,7 +1858,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -1884,7 +1889,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "dailryId" : 16,
@@ -2081,7 +2086,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "pageId" : 5,
@@ -2283,7 +2288,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "pageId" : 5,
@@ -2485,7 +2490,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "dailryId" : 2,
@@ -2589,7 +2594,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -2683,7 +2688,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "postId" : 31,
@@ -2856,7 +2861,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "postId" : 31,
@@ -2965,7 +2970,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "postId" : 31,
@@ -3078,7 +3083,7 @@ Content-Type: application/json;charset=UTF-8
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 사이즈</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지별 게시글 갯수</p></td>
 </tr>
 </tbody>
 </table>
@@ -3088,7 +3093,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "presentPage" : 7,
@@ -3262,7 +3267,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -3270,6 +3275,203 @@ Content-Type: application/json;charset=UTF-8
 }</code></pre>
 </div>
 </div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_인기_게시글">인기 게시글</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_인기게시글_여러건_조회">인기게시글 여러건 조회</h3>
+<div class="sect3">
+<h4 id="_요청_10">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/hotPosts?page=0&amp;size=5 HTTP/1.1</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호(0부터 시작)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지별 게시글 갯수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_31">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "presentPage" : 7,
+  "hasNext" : true,
+  "hotPosts" : [ {
+    "postId" : 36,
+    "content" : "오늘 다일리 어떤가요?",
+    "pageImage" : "https://imageURL123.com",
+    "writerId" : 3,
+    "writerNickname" : "신입생123",
+    "hashtags" : [ "대학생", "시험기간" ],
+    "likeCount" : 5,
+    "createdTime" : "2024-01-18T15:38:32.000000042",
+    "hotPostCreatedTime" : "2024-03-06T17:30:32.000000042"
+  }, {
+    "postId" : 37,
+    "content" : "오늘 다일리 어떤가요~~",
+    "pageImage" : "https://imageURL13.com",
+    "writerId" : 4,
+    "writerNickname" : "다솔맘",
+    "hashtags" : [ "육아" ],
+    "likeCount" : 8,
+    "createdTime" : "2024-01-18T15:38:32.000000042",
+    "hotPostCreatedTime" : "2024-03-06T17:30:32.000000042"
+  }, {
+    "postId" : 38,
+    "content" : "오늘 업무량 실화냐..",
+    "pageImage" : "https://imageURL123.com",
+    "writerId" : 31,
+    "writerNickname" : "다일리개발자",
+    "hashtags" : [ "개발자", "회사", "퇴사" ],
+    "likeCount" : 33,
+    "createdTime" : "2024-01-18T15:38:32.000000042",
+    "hotPostCreatedTime" : "2024-03-06T17:30:32.000000042"
+  }, {
+    "postId" : 39,
+    "content" : "주말 다일리 어떤가요?",
+    "pageImage" : "https://imageURL1413.com",
+    "writerId" : 83,
+    "writerNickname" : "주말좋아",
+    "hashtags" : [ "주말", "휴식" ],
+    "likeCount" : 23,
+    "createdTime" : "2024-01-18T15:38:32.000000042",
+    "hotPostCreatedTime" : "2024-03-06T17:30:32.000000042"
+  }, {
+    "postId" : 40,
+    "content" : "유럽여행 25일차 일정 짜봤습니다.",
+    "pageImage" : "https://imageURL23123.com",
+    "writerId" : 512,
+    "writerNickname" : "여행유튜버",
+    "hashtags" : [ "여행", "유럽여행" ],
+    "likeCount" : 212,
+    "createdTime" : "2024-01-18T15:38:32.000000042",
+    "hotPostCreatedTime" : "2024-03-06T17:30:32.000000042"
+  } ]
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>presentPage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hasNext</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 게시글이 존재하는지 유무</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hotPosts</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인기 게시글 목록 배열</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hotPosts[].postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hotPosts[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 본문 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hotPosts[].pageImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시된 다일리 이미지 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hotPosts[].hashtags</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 해시태그</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hotPosts[].writerId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 작성자 고유 식별자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hotPosts[].writerNickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 작성자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hotPosts[].likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 숫자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hotPosts[].createdTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 생성 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hotPosts[].hotPostCreatedTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인기 게시글로 올라간 시간</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 </div>
@@ -3289,11 +3491,11 @@ Content-Type: */*;charset=UTF-8</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_응답_31">응답</h4>
+<h4 id="_응답_32">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -3315,11 +3517,11 @@ Content-Type: */*;charset=UTF-8</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_응답_32">응답</h4>
+<h4 id="_응답_33">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -3393,11 +3595,11 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_33">응답</h4>
+<h4 id="_응답_34">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "commentId" : 16,
@@ -3524,11 +3726,11 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_34">응답</h4>
+<h4 id="_응답_35">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "commentId" : 16,
@@ -3599,7 +3801,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_댓글_조회">댓글 조회</h3>
 <div class="sect3">
-<h4 id="_요청_10">요청</h4>
+<h4 id="_요청_11">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/posts/31/comments?page=0&amp;size=3 HTTP/1.1</code></pre>
@@ -3652,11 +3854,11 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_35">응답</h4>
+<h4 id="_응답_36">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "presentPage" : 0,
@@ -3772,11 +3974,11 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_36">응답</h4>
+<h4 id="_응답_37">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
+Content-Type: application/json
 
 {
   "statusCode" : 200,
@@ -3792,7 +3994,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-22 13:57:55 +0900
+Last updated 2024-03-06 18:48:55 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/daily/daily/post/controller/HotPostControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/HotPostControllerTest.java
@@ -1,0 +1,75 @@
+package com.daily.daily.post.controller;
+
+import com.daily.daily.auth.jwt.JwtAuthorizationFilter;
+import com.daily.daily.auth.jwt.JwtUtil;
+import com.daily.daily.post.dto.HotPostReadSliceResponseDTO;
+import com.daily.daily.post.fixture.HotPostFixture;
+import com.daily.daily.post.service.HotPostService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = HotPostController.class, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
+})
+@AutoConfigureRestDocs
+class HotPostControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    HotPostService hotPostService;
+
+    @Nested
+    @DisplayName("readSlice() - 인기 게시글 여러건 조회기능 테스트")
+    class readSlice{
+        @Test
+        @DisplayName("인기게시글을 여러건 조회가 성공했을 때 응답 결과를 검사한다.")
+        @WithMockUser
+        void test1() throws Exception {
+            //given
+            HotPostReadSliceResponseDTO 인기_게시글_여러건_조회_DTO = HotPostFixture.인기_게시글_여러건_조회_DTO();
+            given(hotPostService.findSlice(PageRequest.of(0,5))).willReturn(인기_게시글_여러건_조회_DTO);
+
+            //when
+            ResultActions perform = mockMvc.perform(get("/api/hotPosts")
+                    .with(csrf().asHeader())
+                    .queryParam("page", "0")
+                    .queryParam("size", "5")
+            );
+
+            //then
+            String content = perform.andExpect(status().isOk())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString(StandardCharsets.UTF_8);
+
+            HotPostReadSliceResponseDTO 테스트_조회_결과 = objectMapper.readValue(content, HotPostReadSliceResponseDTO.class);
+            assertThat(테스트_조회_결과).isEqualTo(인기_게시글_여러건_조회_DTO);
+        }
+    }
+}

--- a/backend/src/test/java/com/daily/daily/post/controller/HotPostControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/HotPostControllerTest.java
@@ -22,9 +22,18 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
 
+import static com.daily.daily.testutil.document.RestDocsUtil.document;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -70,6 +79,28 @@ class HotPostControllerTest {
 
             HotPostReadSliceResponseDTO 테스트_조회_결과 = objectMapper.readValue(content, HotPostReadSliceResponseDTO.class);
             assertThat(테스트_조회_결과).isEqualTo(인기_게시글_여러건_조회_DTO);
+            
+            //restdocs
+            perform.andDo(document("인기 게시글 여러건 조회",
+                    queryParameters(
+                            parameterWithName("page").description("페이지 번호(0부터 시작)"),
+                            parameterWithName("size").description("페이지별 게시글 갯수")
+                    ),
+                    responseFields(
+                            fieldWithPath("presentPage").type(NUMBER).description("현재 페이지 번호"),
+                            fieldWithPath("hasNext").type(BOOLEAN).description("다음 게시글이 존재하는지 유무"),
+                            fieldWithPath("hotPosts").type(ARRAY).description("인기 게시글 목록 배열"),
+                            fieldWithPath("hotPosts[].postId").type(NUMBER).description("게시글 id"),
+                            fieldWithPath("hotPosts[].content").type(STRING).description("게시글 본문 내용"),
+                            fieldWithPath("hotPosts[].pageImage").type(STRING).description("게시된 다일리 이미지 URL"),
+                            fieldWithPath("hotPosts[].hashtags").type(ARRAY).description("게시글 해시태그"),
+                            fieldWithPath("hotPosts[].writerId").type(NUMBER).description("게시글 작성자 고유 식별자"),
+                            fieldWithPath("hotPosts[].writerNickname").type(STRING).description("게시글 작성자 닉네임"),
+                            fieldWithPath("hotPosts[].likeCount").type(NUMBER).description("좋아요 숫자"),
+                            fieldWithPath("hotPosts[].createdTime").type(STRING).description("게시글 생성 시간"),
+                            fieldWithPath("hotPosts[].hotPostCreatedTime").type(STRING).description("인기 게시글로 올라간 시간")
+                    )
+            ));
         }
     }
 }

--- a/backend/src/test/java/com/daily/daily/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/PostControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;

--- a/backend/src/test/java/com/daily/daily/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/PostControllerTest.java
@@ -296,7 +296,7 @@ class PostControllerTest {
             perform.andDo(RestDocsUtil.document("게시글 여러건 조회",
                     queryParameters(
                             parameterWithName("page").description("페이지 번호(0부터 시작)"),
-                            parameterWithName("size").description("페이지 사이즈")
+                            parameterWithName("size").description("페이지별 게시글 갯수")
                     ),
                     responseFields(
                             fieldWithPath("presentPage").type(NUMBER).description("현재 페이지 번호"),

--- a/backend/src/test/java/com/daily/daily/post/controller/PostLikeControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/post/controller/PostLikeControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -43,8 +42,8 @@ class PostLikeControllerTest {
     @Autowired
     ObjectMapper objectMapper;
 
-//    @MockBean
-//    PostLikeService postLikeService;
+    @MockBean
+    PostLikeService postLikeService;
 
     @MockBean
     PostLikeFacade postLikeFacade;

--- a/backend/src/test/java/com/daily/daily/post/fixture/HotPostFixture.java
+++ b/backend/src/test/java/com/daily/daily/post/fixture/HotPostFixture.java
@@ -1,0 +1,83 @@
+package com.daily.daily.post.fixture;
+
+import com.daily.daily.post.dto.HotPostReadResponseDTO;
+import com.daily.daily.post.dto.HotPostReadSliceResponseDTO;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.daily.daily.post.fixture.PostFixture.POST_CREATED_TIME;
+
+
+public class HotPostFixture {
+
+    private static final LocalDateTime HOT_POST_CREATED_TIME =  LocalDateTime.of(2024,3,6,17,30,32,42);
+    public static HotPostReadSliceResponseDTO 인기_게시글_여러건_조회_DTO() {
+        HotPostReadResponseDTO 인기게시글1 = HotPostReadResponseDTO.builder()
+                .postId(36L)
+                .content("오늘 다일리 어떤가요?")
+                .pageImage("https://imageURL123.com")
+                .writerId(3L)
+                .writerNickname("신입생123")
+                .hashtags(List.of("대학생", "시험기간"))
+                .createdTime(POST_CREATED_TIME)
+                .hotPostCreatedTime(HOT_POST_CREATED_TIME)
+                .likeCount(5L)
+                .build();
+
+        HotPostReadResponseDTO 인기게시글2 = HotPostReadResponseDTO.builder()
+                .postId(37L)
+                .content("오늘 다일리 어떤가요~~")
+                .pageImage("https://imageURL13.com")
+                .writerId(4L)
+                .writerNickname("다솔맘")
+                .hashtags(List.of("육아"))
+                .createdTime(POST_CREATED_TIME)
+                .hotPostCreatedTime(HOT_POST_CREATED_TIME)
+                .likeCount(8L)
+                .build();
+
+        HotPostReadResponseDTO 인기게시글3 = HotPostReadResponseDTO.builder()
+                .postId(38L)
+                .content("오늘 업무량 실화냐..")
+                .pageImage("https://imageURL123.com")
+                .writerId(31L)
+                .writerNickname("다일리개발자")
+                .hashtags(List.of("개발자", "회사", "퇴사"))
+                .createdTime(POST_CREATED_TIME)
+                .hotPostCreatedTime(HOT_POST_CREATED_TIME)
+                .likeCount(33L)
+                .build();
+
+        HotPostReadResponseDTO 인기게시글4 = HotPostReadResponseDTO.builder()
+                .postId(39L)
+                .content("주말 다일리 어떤가요?")
+                .pageImage("https://imageURL1413.com")
+                .writerId(83L)
+                .writerNickname("주말좋아")
+                .hashtags(List.of("주말", "휴식"))
+                .createdTime(POST_CREATED_TIME)
+                .hotPostCreatedTime(HOT_POST_CREATED_TIME)
+                .likeCount(23L)
+                .build();
+
+        HotPostReadResponseDTO 인기게시글5 = HotPostReadResponseDTO.builder()
+                .postId(40L)
+                .content("유럽여행 25일차 일정 짜봤습니다.")
+                .pageImage("https://imageURL23123.com")
+                .writerId(512L)
+                .writerNickname("여행유튜버")
+                .hashtags(List.of("여행", "유럽여행"))
+                .createdTime(POST_CREATED_TIME)
+                .hotPostCreatedTime(HOT_POST_CREATED_TIME)
+                .likeCount(212L)
+                .build();
+
+        return HotPostReadSliceResponseDTO
+                .builder()
+                .hasNext(true)
+                .presentPage(7)
+                .hotPosts(List.of(인기게시글1, 인기게시글2, 인기게시글3, 인기게시글4, 인기게시글5))
+                .build();
+    }
+}

--- a/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
+++ b/backend/src/test/java/com/daily/daily/post/fixture/PostFixture.java
@@ -14,10 +14,8 @@ import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingExcept
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.daily.daily.member.fixture.MemberFixture.일반회원1;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -29,7 +27,7 @@ public class PostFixture {
     public static final Long POST_ID = 31L;
     private static final String POST_CONTENT = "오늘 저의 다일리입니다.";
     private static final String PAGE_IMAGE_URL = "imageURL";
-    private static final LocalDateTime POST_CREATED_TIME = LocalDateTime.of(2024,1,18,15,38,32,42);
+    public static final LocalDateTime POST_CREATED_TIME = LocalDateTime.of(2024,1,18,15,38,32,42);
     private static final List<String> HASHTAG_NAMES = List.of("일반", "음식", "대학생");
     private static final List<Hashtag> HASHTAGS = HASHTAG_NAMES.stream()
             .map(Hashtag::of)

--- a/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceConcurrencyTest.java
@@ -1,5 +1,6 @@
 package com.daily.daily.post.service;
 
+import com.daily.daily.common.config.BusinessConfig;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.exception.PostNotFoundException;
@@ -99,13 +100,13 @@ public class PostLikeServiceConcurrencyTest {
     }
 
     @Test
-    @DisplayName("post 의 좋아요가 14인 상황에서 동시에 좋아요 요청이 5개 왔을 때, hot_post 테이블에 중복된 post 가 저장되면 안된다." +
+    @DisplayName("post 의 좋아요가 인기글 기준치에 1만큼 못미친 상황에서 동시에 좋아요 요청이 5개 왔을 때, hot_post 테이블에 중복된 post 가 저장되면 안된다." +
             "Unique 제약조건으로 인한 예외로 좋아요 요청이 실패해서도 안된다.")
     void hotPostInsertConcurrencyTest() throws InterruptedException {
         //given
         hotPostRepository.deleteAll();
 
-        List<Member> members = memberGenerator.generate(14);
+        List<Member> members = memberGenerator.generate(BusinessConfig.HOT_POST_LIKE_THRESHOLD - 1);
         Post post = postGenerator.generate();
 
         for (Member member : members) {

--- a/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceConcurrencyTest.java
@@ -3,14 +3,15 @@ package com.daily.daily.post.service;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.exception.PostNotFoundException;
+import com.daily.daily.post.repository.HotPostRepository;
 import com.daily.daily.post.repository.PostRepository;
 import com.daily.daily.testutil.generator.MemberGenerator;
 import com.daily.daily.testutil.generator.PostGenerator;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.testcontainers.shaded.org.checkerframework.checker.units.qual.C;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -32,7 +33,13 @@ public class PostLikeServiceConcurrencyTest {
     PostRepository postRepository;
 
     @Autowired
+    HotPostRepository hotPostRepository;
+
+    @Autowired
     PostLikeFacade postLikeFacade;
+
+    @Autowired
+    EntityManager em;
     @Test
     @DisplayName("동시에 좋아요 요청이 50개 왔을 때, 좋아요의 갯수가 50이 오르는지 확인한다. " +
             "그리고 이후에 좋아요 해제 요청이 동시에 30개가 왔을 때 전체 좋아요의 갯수는 20이어야 한다.")
@@ -51,9 +58,10 @@ public class PostLikeServiceConcurrencyTest {
             executorService.submit(() -> {
                 try {
                     postLikeFacade.increaseLikeCount(member.getId(), post.getId());
-                    latch.countDown();
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
                 }
             });
         }
@@ -75,9 +83,10 @@ public class PostLikeServiceConcurrencyTest {
             executorService.submit(() -> {
                 try {
                     postLikeFacade.decreaseLikeCount(member.getId(), post.getId());
-                    latch2.countDown();
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
+                } finally {
+                    latch2.countDown();
                 }
             });
         }
@@ -87,5 +96,41 @@ public class PostLikeServiceConcurrencyTest {
         //then
         Post postWithDecreasedLikes = postRepository.findById(post.getId()).orElseThrow(PostNotFoundException::new);
         assertThat(postWithDecreasedLikes.getLikeCount()).isEqualTo(20); //50 - 30 = 20   (좋아요 증가 요청 - 좋아요 감소 요청)
+    }
+
+    @Test
+    @DisplayName("post 의 좋아요가 14인 상황에서 동시에 좋아요 요청이 5개 왔을 때, hot_post 테이블에 중복된 post 가 저장되면 안된다." +
+            "Unique 제약조건으로 인한 예외로 좋아요 요청이 실패해서도 안된다.")
+    void hotPostInsertConcurrencyTest() throws InterruptedException {
+        //given
+        hotPostRepository.deleteAll();
+
+        List<Member> members = memberGenerator.generate(14);
+        Post post = postGenerator.generate();
+
+        for (Member member : members) {
+            postLikeFacade.increaseLikeCount(member.getId(), post.getId()); //좋아요 갯수를 14로 만들기. 15가 되면 인기글로 올라간다.
+        }
+
+        int concurrentRequest = 5;
+        List<Member> concurrentMembers = memberGenerator.generate(concurrentRequest);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(8);
+        CountDownLatch latch = new CountDownLatch(concurrentRequest);
+
+        //when
+        for (Member member : concurrentMembers) {
+            executorService.submit(() -> {
+                try {
+                    postLikeFacade.increaseLikeCount(member.getId(), post.getId());
+                    latch.countDown();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        //then
+        assertThat(hotPostRepository.count()).isEqualTo(1);
     }
 }

--- a/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceConcurrencyTest.java
@@ -1,6 +1,6 @@
 package com.daily.daily.post.service;
 
-import com.daily.daily.common.config.BusinessConfig;
+import com.daily.daily.common.config.Business.BusinessConfig;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.post.domain.Post;
 import com.daily.daily.post.exception.PostNotFoundException;

--- a/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceTest.java
@@ -172,7 +172,7 @@ class PostLikeServiceTest {
     @DisplayName("decreaseLikeCount() - 좋아요 감소 메서드 테스트")
     class decreaseLikeCount{
         @Test
-        @DisplayName("memberId와 postId로 좋아요 이력을 조회 했을 때, 좋아요를 누른 이력이 없는데, 좋아요를 감소시키려고 하는 경우 LikeDecreaseNotAllowedException 예외를 발생한다")
+        @DisplayName("memberId와 postId로 좋아요 이력을 조회 했을 때, 좋아요를 누른 이력이 없는데, 좋아요를 감소시키려고 하는 경우 NotPreviouslyLikedException 예외를 발생한다")
         void test1() {
             //given
             when(likeRepository.findBy(any(Long.class), any(Long.class))).thenReturn(Optional.empty());

--- a/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceTest.java
@@ -20,8 +20,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static com.daily.daily.common.config.BusinessConfig.HOT_POST_LIKE_THRESHOLD;
-import static com.daily.daily.common.config.BusinessConfig.HOT_POST_CREATED_TIME_CONDITION;
+import static com.daily.daily.common.config.Business.BusinessConfig.HOT_POST_LIKE_THRESHOLD;
+import static com.daily.daily.common.config.Business.BusinessConfig.HOT_POST_CREATED_TIME_CONDITION;
 import static com.daily.daily.member.fixture.MemberFixture.일반회원2;
 import static com.daily.daily.post.fixture.PostFixture.일반회원1이_작성한_게시글;
 import static java.time.LocalDateTime.now;

--- a/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostLikeServiceTest.java
@@ -17,18 +17,21 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
+import static com.daily.daily.common.config.BusinessConfig.HOT_POST_LIKE_THRESHOLD;
+import static com.daily.daily.common.config.BusinessConfig.HOT_POST_CREATED_TIME_CONDITION;
 import static com.daily.daily.member.fixture.MemberFixture.일반회원2;
 import static com.daily.daily.post.fixture.PostFixture.일반회원1이_작성한_게시글;
+import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @ExtendWith(MockitoExtension.class)
 class PostLikeServiceTest {
@@ -87,12 +90,33 @@ class PostLikeServiceTest {
         }
 
         @Test
-        @DisplayName("게시글의 좋아요 갯수가 15가 되면 해당 게시글은 HotPost 테이블에 저장되어야 한다.")
+        @DisplayName("게시글의 좋아요 갯수가 기준치에 만족하고, 생성시간 조건도 만족한다면 해당 게시글은 HotPost 테이블에 저장되어야 한다.")
         void test3() {
             //given
             Member 일반회원2 = 일반회원2();
             Post 일반회원1이_작성한_게시글 = 일반회원1이_작성한_게시글();
-            ReflectionTestUtils.setField(일반회원1이_작성한_게시글, "likeCount", 14); // 좋아요 갯수를 14로 설정
+            setField(일반회원1이_작성한_게시글, "likeCount", HOT_POST_LIKE_THRESHOLD -1); // 좋아요 갯수를 기준에 1못미치게 설정
+            setField(일반회원1이_작성한_게시글, "createdTime", now().minusDays(HOT_POST_CREATED_TIME_CONDITION).plusSeconds(1));
+
+            when(memberRepository.findById(any())).thenReturn(Optional.of(일반회원2));
+            when(postRepository.findById(any())).thenReturn(Optional.of(일반회원1이_작성한_게시글));
+
+            //when
+            postLikeService.increaseLikeCount(일반회원2.getId(), 일반회원1이_작성한_게시글.getId()); // 좋아요를 누름으로써 인기글 생성
+
+            //then
+            verify(hotPostRepository, times(1)).save(any());
+        }
+
+        @Test
+        @DisplayName("게시글의 좋아요 갯수가 기준치를 만족하더라도, 이미 인기글에 올라간 게시글의 경우에는 HotPost 테이블에 저장하지 않는다.")
+        void test4() {
+            //given
+            Member 일반회원2 = 일반회원2();
+            Post 일반회원1이_작성한_게시글 = 일반회원1이_작성한_게시글();
+            setField(일반회원1이_작성한_게시글, "likeCount", HOT_POST_LIKE_THRESHOLD -1);
+            setField(일반회원1이_작성한_게시글, "createdTime", now().minusDays(HOT_POST_CREATED_TIME_CONDITION).plusSeconds(1));
+            setField(일반회원1이_작성한_게시글, "isHotPost", true); // 이미 HotPost 인 경우.
 
             when(memberRepository.findById(any())).thenReturn(Optional.of(일반회원2));
             when(postRepository.findById(any())).thenReturn(Optional.of(일반회원1이_작성한_게시글));
@@ -101,17 +125,36 @@ class PostLikeServiceTest {
             postLikeService.increaseLikeCount(일반회원2.getId(), 일반회원1이_작성한_게시글.getId());
 
             //then
-            verify(hotPostRepository, times(1)).save(any());
+            verify(hotPostRepository, times(0)).save(any());
         }
-
+        
         @Test
-        @DisplayName("게시글의 좋아요 갯수가 15이상이더라도, 이미 인기글에 올라간 게시글의 경우에는 HotPost 테이블에 저장하지 않는다.")
-        void test4() {
+        @DisplayName("게시글의 좋아요 갯수가 기준치를 만족하더라도, 생성된지 7일이 넘은 게시글의 경우에는 HotPost 테이블에 저장하지 않는다.")
+        void test5() {
             //given
             Member 일반회원2 = 일반회원2();
             Post 일반회원1이_작성한_게시글 = 일반회원1이_작성한_게시글();
-            ReflectionTestUtils.setField(일반회원1이_작성한_게시글, "likeCount", 16); // 좋아요 갯수를 16으로 설정
-            ReflectionTestUtils.setField(일반회원1이_작성한_게시글, "isHotPost", true); // 이미 HotPost 인 경우.
+            setField(일반회원1이_작성한_게시글, "likeCount", HOT_POST_LIKE_THRESHOLD -1);
+            setField(일반회원1이_작성한_게시글, "createdTime", now().minusDays(HOT_POST_CREATED_TIME_CONDITION));
+
+            when(memberRepository.findById(any())).thenReturn(Optional.of(일반회원2));
+            when(postRepository.findById(any())).thenReturn(Optional.of(일반회원1이_작성한_게시글));
+
+            //when
+            postLikeService.increaseLikeCount(일반회원2.getId(), 일반회원1이_작성한_게시글.getId());
+
+            //then
+            verify(hotPostRepository, times(0)).save(any());
+        }
+
+        @Test
+        @DisplayName("게시글의 좋아요 갯수가 기준치에 만족하지 않으면, HotPost 테이블에 저장되지 않는다.")
+        void test6() {
+            //given
+            Member 일반회원2 = 일반회원2();
+            Post 일반회원1이_작성한_게시글 = 일반회원1이_작성한_게시글();
+            setField(일반회원1이_작성한_게시글, "likeCount", HOT_POST_LIKE_THRESHOLD - 2);
+            setField(일반회원1이_작성한_게시글, "createdTime", now().minusDays(HOT_POST_CREATED_TIME_CONDITION).plusSeconds(1));
 
             when(memberRepository.findById(any())).thenReturn(Optional.of(일반회원2));
             when(postRepository.findById(any())).thenReturn(Optional.of(일반회원1이_작성한_게시글));


### PR DESCRIPTION
## 연관 이슈
close: #263 
## 작업 내용
- DB 스키마 수정
   - hot_post 테이블 추가
   - post 테이블에 is_hot_post 컬럼 추가 (type : boolean)
- 좋아요를 많이 받은 인기 다일리 페이지 게시글(이하 인기글)을 별도로 조회할 수 있다.
- 최근 7일 동안 올라온 글 중에서 좋아요 갯수가 15이상이 되면 인기글이 된다.

## 의논할 거리

## Merge 전에 해야할 작업

## 기타

- common/config/business 패키지에  BusinessConfig 클래스를 만들었습니다.
- 비즈니스 관련된 설정들을 여기에서 하면 좋을 것 같습니다. (ex : 인기 게시글로 올라가는 좋아요 기준치 등) 
   - 굳이 따로 분리해서 비즈니스 로직에 관한 상수 클래스를 만든 이유는 비즈니스 설정을 변경하였을 때,
      테스트코드가 깨지는 것을 방지하기 위해서 입니다.
      테스트코드 에서도 매직 넘버가 아닌, 해당 상수를 쓰도록 하는 것이 변경에 더 수월할 것 같습니다.
   
