### PR TITLE
다일리 페이지 삭제 버그 수정

### DIFF
--- a/backend/src/main/java/com/daily/daily/dailrypage/domain/DailryPage.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/domain/DailryPage.java
@@ -47,16 +47,8 @@ public class DailryPage extends BaseTimeEntity {
     protected DailryPage() {
     }
 
-    public static DailryPage createEmptyPage() {
-        return new DailryPage();
-    }
-
     public void updateBackground(String background) {
         this.background = background;
-    }
-
-    public void updatePageNumber(int pageNumber) {
-        this.pageNumber = pageNumber;
     }
 
     public void updateElements(List<DailryPageUpdateDTO.ElementDTO> elements) {

--- a/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageQuerydsl.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageQuerydsl.java
@@ -1,10 +1,11 @@
 package com.daily.daily.dailrypage.repository;
 
+import com.daily.daily.dailrypage.domain.DailryPage;
 import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
 
 import java.util.List;
 
 public interface DailryPageQuerydsl {
     List<DailryPageThumbnailDTO> findThumbnails(Long dailryId);
-
+    void deleteAndAdjustPageNumber(DailryPage dailryPage);
 }

--- a/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageQuerydslImpl.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/repository/DailryPageQuerydslImpl.java
@@ -1,6 +1,6 @@
 package com.daily.daily.dailrypage.repository;
 
-import com.daily.daily.dailrypage.domain.QDailryPage;
+import com.daily.daily.dailrypage.domain.DailryPage;
 import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -26,5 +26,21 @@ public class DailryPageQuerydslImpl implements DailryPageQuerydsl {
                 .from(dailryPage)
                 .where(dailryPage.dailry.id.eq(dailryId))
                 .fetch();
+    }
+    @Override
+    public void deleteAndAdjustPageNumber(DailryPage page) {
+        queryFactory.delete(dailryPage)
+                .where(dailryPage.id.eq(page.getId()))
+                .execute();
+
+        adjustPageNumber(page.getDailryId(), page.getPageNumber());
+    }
+
+    private void adjustPageNumber(Long dailryId, Integer pageNumberOfDeletedPage) {
+        queryFactory.update(dailryPage)
+                .set(dailryPage.pageNumber, dailryPage.pageNumber.subtract(1))
+                .where(dailryPage.dailry.id.eq(dailryId)
+                        .and(dailryPage.pageNumber.gt(pageNumberOfDeletedPage))
+                ).execute();
     }
 }

--- a/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
@@ -108,6 +108,7 @@ public class DailryPageService {
         if (!findPage.belongsTo(memberId)) {
             throw new UnauthorizedAccessException();
         }
-        dailryPageRepository.deleteById(pageId);
+
+        dailryPageRepository.deleteAndAdjustPageNumber(findPage);
     }
 }

--- a/backend/src/test/java/com/daily/daily/dailrypage/repository/DailryPageQuerydslImplTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/repository/DailryPageQuerydslImplTest.java
@@ -1,10 +1,12 @@
 package com.daily.daily.dailrypage.repository;
 
 import com.daily.daily.dailry.domain.Dailry;
+import com.daily.daily.dailrypage.domain.DailryPage;
 import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
 import com.daily.daily.testutil.config.JpaTest;
 import com.daily.daily.testutil.generator.DailryGenerator;
 import com.daily.daily.testutil.generator.DailryPageGenerator;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +26,9 @@ class DailryPageQuerydslImplTest extends JpaTest {
     @Autowired
     DailryPageGenerator dailryPageGenerator;
 
+    @Autowired
+    EntityManager em;
+
     @Test
     @DisplayName("다일리 썸네일 조회 메서드를 테스트한다.")
     void findThumbnails() {
@@ -40,5 +45,31 @@ class DailryPageQuerydslImplTest extends JpaTest {
         //then
         assertThat(thumbnails).hasSize(3);
         assertThat(otherThumbnails).isEmpty();
+    }
+
+    @Test
+    @DisplayName("다일리 페이지 삭제 후, 삭제된 페이지의 pageNumber 보다 pageNumber 값이 큰 페이지들은, pageNumber가 1씩 당겨져야한다.")
+    void deleteAndAdjustPageNumber() {
+        //given
+        Dailry dailry = dailryGenerator.generate();
+        List<DailryPage> dailryPages = dailryPageGenerator.generate(dailry, 10); // 테스트용 다일리 페이지 10개
+
+        DailryPage firstPage = dailryPages.get(0);
+        //when
+        dailryPageRepository.deleteAndAdjustPageNumber(firstPage);
+        em.flush();
+        em.clear();
+
+        //then
+        List<DailryPage> updatedDailryPages = em.createQuery("select dp from DailryPage dp where dp.dailry.id = :dailryId",
+                        DailryPage.class)
+                .setParameter("dailryId", dailry.getId())
+                .getResultList();
+
+        assertThat(updatedDailryPages).hasSize(9); // 페이지가 삭제되었는지 확인
+        int pageNumber = 1;
+        for (DailryPage page : updatedDailryPages) {
+            assertThat(page.getPageNumber()).isEqualTo(pageNumber++); // 페이지 넘버가 당겨졌는지 확인
+        }
     }
 }

--- a/backend/src/test/java/com/daily/daily/testutil/generator/DailryPageGenerator.java
+++ b/backend/src/test/java/com/daily/daily/testutil/generator/DailryPageGenerator.java
@@ -16,13 +16,17 @@ public class DailryPageGenerator {
     DailryPageRepository dailryPageRepository;
 
     public List<DailryPage> generate(Dailry dailry, int count) {
-        List<DailryPage> dailryPages = new ArrayList<>();
+        List<DailryPage> result = new ArrayList<>();
         
         for (int i = 1; i <= count; i++) {
-            DailryPage dailryPage = DailryPage.builder().dailry(dailry).build();
-            dailryPages.add(dailryPageRepository.save(dailryPage));
+            DailryPage dailryPage = DailryPage.builder()
+                    .dailry(dailry)
+                    .pageNumber(i)
+                    .build();
+
+            result.add(dailryPageRepository.save(dailryPage));
         }
 
-        return dailryPages;
+        return result;
     }
 }


### PR DESCRIPTION
## 연관 이슈
close: #274 
## 작업 내용

-  페이지를 삭제시, 해당 페이지 이후의 pageNumber를 1씩당기는 로직을 추가

## 의논할 거리

음 일단 삭제되는 페이지의 pageNumber 보다 큰 페이지를 -1 하도록

업데이트 쿼리를 날려서 해결을 했는데요.. 

(delete 쿼리 하나, 벌크성 update 쿼리 하나, 두 개 나갑니다.)

이 방법이 최선인지는 잘 모르겠네요. 

가장 큰 문제는 pageNumber의 무결성이 한 번 깨지면 대처가 안된다는 점인데요.. 

(ex : 잘못해서 페이지 삭제 API가 순간적으로 두 번 호출된다면? 모든 pageNumber가 다 깨지게 됨.)

이 부분은 조금 의논을 해봐야 할 것 같습니다.

## Merge 전에 해야할 작업

## 기타
