### PR TITLE
다일리 페이지 수정 API 꾸미기 컴포넌트 삭제 기능 반영하기 / S3 Storage 리팩토링

### DIFF
--- a/backend/src/main/java/com/daily/daily/common/domain/DirectoryPath.java
+++ b/backend/src/main/java/com/daily/daily/common/domain/DirectoryPath.java
@@ -1,0 +1,38 @@
+package com.daily.daily.common.domain;
+
+import com.daily.daily.common.exception.InvalidDirectoryException;
+
+public class DirectoryPath {
+    private static final String DELIMITER = "/";
+    private String path; // ex : /dir1/dir2/dir3/ ... ./dir50
+
+    private DirectoryPath(String[] directories) {
+        validateDirectories(directories);
+
+        StringBuilder builder = new StringBuilder(DELIMITER);
+        for (String directory : directories) {
+            builder.append(directory).append(DELIMITER);
+        }
+        this.path = builder.substring(0, builder.length() - DELIMITER.length()); // 마지막 디렉토리 DELIMITER 제거.
+    }
+
+    public static DirectoryPath of(String... directories) {
+        return new DirectoryPath(directories);
+    }
+
+    private static void validateDirectories(String[] directories) {
+        if (directories == null || directories.length == 0) {
+            throw new InvalidDirectoryException();
+        }
+
+        for (String directory : directories) {
+            if (directory == null || directory.isBlank()) {
+                throw new InvalidDirectoryException();
+            }
+        }
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/backend/src/main/java/com/daily/daily/common/exception/InvalidDirectoryException.java
+++ b/backend/src/main/java/com/daily/daily/common/exception/InvalidDirectoryException.java
@@ -1,0 +1,7 @@
+package com.daily.daily.common.exception;
+
+public class InvalidDirectoryException extends RuntimeException {
+    public InvalidDirectoryException() {
+        super("올바르지 않은 디렉토리 경로입니다");
+    }
+}

--- a/backend/src/main/java/com/daily/daily/dailrypage/domain/DailryPage.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/domain/DailryPage.java
@@ -51,10 +51,14 @@ public class DailryPage extends BaseTimeEntity {
         this.background = background;
     }
 
-    public void updateElements(List<DailryPageUpdateDTO.ElementDTO> elements) {
-        for (DailryPageUpdateDTO.ElementDTO element : elements) {
-            this.elements.put(element.getId(), element);
-        }
+    public void addOrUpdateElements(List<DailryPageUpdateDTO.ElementDTO> elementsDTO) {
+        if (elementsDTO == null || elementsDTO.isEmpty()) return;
+        elementsDTO.forEach(element -> elements.put(element.getId(), element));
+    }
+
+    public void deleteElements(List<String> deletedElementsId) {
+        if (deletedElementsId == null || deletedElementsId.isEmpty()) return;
+        deletedElementsId.forEach(id -> elements.remove(id));
     }
 
     public void updateThumbnail(String thumbnail) {

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageDTO.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Collection;
+
 
 @Getter
 @Setter
@@ -16,15 +18,17 @@ public class DailryPageDTO {
     private String background;
     private String thumbnail;
     private int pageNumber;
-    private Object elements;
+    private Collection<Object> elements;
 
     public static DailryPageDTO from(DailryPage dailryPage) {
+        Collection<Object> elements = dailryPage.getElements().values();
+
         return DailryPageDTO.builder()
                 .pageId(dailryPage.getId())
                 .background(dailryPage.getBackground())
                 .thumbnail(dailryPage.getThumbnail())
                 .pageNumber(dailryPage.getPageNumber())
-                .elements(dailryPage.getElements().values())
+                .elements(elements)
                 .build();
     }
 

--- a/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageUpdateDTO.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/dto/DailryPageUpdateDTO.java
@@ -18,6 +18,8 @@ public class DailryPageUpdateDTO {
     @NotBlank(message = "background는 비어있을 수 없습니다.")
     private String background;
 
+    private List<String> deletedElementIds;
+
     @Valid
     private List<ElementDTO> elements;
 

--- a/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
@@ -1,12 +1,17 @@
 package com.daily.daily.dailrypage.service;
 
 import com.daily.daily.common.exception.UnauthorizedAccessException;
+import com.daily.daily.common.domain.DirectoryPath;
 import com.daily.daily.common.service.S3StorageService;
 import com.daily.daily.dailry.domain.Dailry;
 import com.daily.daily.dailry.exception.DailryNotFoundException;
 import com.daily.daily.dailry.repository.DailryRepository;
 import com.daily.daily.dailrypage.domain.DailryPage;
-import com.daily.daily.dailrypage.dto.*;
+import com.daily.daily.dailrypage.dto.DailryPageCreateResponseDTO;
+import com.daily.daily.dailrypage.dto.DailryPageDTO;
+import com.daily.daily.dailrypage.dto.DailryPagePreviewDTO;
+import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
+import com.daily.daily.dailrypage.dto.DailryPageUpdateDTO;
 import com.daily.daily.dailrypage.exception.DailryPageNotFoundException;
 import com.daily.daily.dailrypage.exception.DailryPageThumbnailNotFoundException;
 import com.daily.daily.dailrypage.repository.DailryPageRepository;
@@ -15,15 +20,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
+import java.net.URI;
 import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class DailryPageService {
-    private final String THUMBNAIL_STORAGE_DIRECTORY_PATH = "thumbnail/%s/%s/" + LocalDate.now(ZoneId.of("Asia/Seoul"));
 
     private final DailryPageRepository dailryPageRepository;
 
@@ -64,7 +67,7 @@ public class DailryPageService {
         findPage.addOrUpdateElements(dailryPageUpdateDTO.getElements());
         findPage.deleteElements(dailryPageUpdateDTO.getDeletedElementIds());
 
-        uploadThumbnail(findPage, thumbnail, memberId, findPage.getDailry().getId());
+        uploadThumbnail(findPage, thumbnail, memberId, findPage.getDailryId());
         return DailryPageDTO.from(findPage);
     }
 
@@ -73,8 +76,11 @@ public class DailryPageService {
             throw new DailryPageThumbnailNotFoundException();
         }
 
-        String fileUrl = storageService.uploadImage(thumbnail, String.format(THUMBNAIL_STORAGE_DIRECTORY_PATH, memberId, dailryId), findPage.getId().toString());
-        findPage.updateThumbnail(fileUrl);
+        DirectoryPath dirPath
+                = DirectoryPath.of("thumbnail", memberId.toString(), dailryId.toString());
+
+        URI thumbnailUri = storageService.uploadImage(thumbnail, dirPath, findPage.getId().toString() + ".png");
+        findPage.updateThumbnail(thumbnailUri.toString()); // 저장경로 : thumbnail/{memberId}/{dailryId}/{pageId}.png
     }
 
 

--- a/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
+++ b/backend/src/main/java/com/daily/daily/dailrypage/service/DailryPageService.java
@@ -53,25 +53,26 @@ public class DailryPageService {
     }
 
     public DailryPageDTO update(Long memberId, Long pageId, DailryPageUpdateDTO dailryPageUpdateDTO, MultipartFile thumbnail) {
-
         DailryPage findPage = dailryPageRepository.findById(pageId)
                 .orElseThrow(DailryPageNotFoundException::new);
 
         if (!findPage.belongsTo(memberId)) {
             throw new UnauthorizedAccessException();
         }
-        findPage.updateBackground(dailryPageUpdateDTO.getBackground());
-        findPage.updateElements(dailryPageUpdateDTO.getElements());
 
-        if (thumbnail == null || thumbnail.isEmpty()) {
-            throw new DailryPageThumbnailNotFoundException();
-        }
+        findPage.updateBackground(dailryPageUpdateDTO.getBackground());
+        findPage.addOrUpdateElements(dailryPageUpdateDTO.getElements());
+        findPage.deleteElements(dailryPageUpdateDTO.getDeletedElementIds());
 
         uploadThumbnail(findPage, thumbnail, memberId, findPage.getDailry().getId());
         return DailryPageDTO.from(findPage);
     }
 
     private void uploadThumbnail(DailryPage findPage, MultipartFile thumbnail, Long memberId, Long dailryId) {
+        if (thumbnail == null || thumbnail.isEmpty()) {
+            throw new DailryPageThumbnailNotFoundException();
+        }
+
         String fileUrl = storageService.uploadImage(thumbnail, String.format(THUMBNAIL_STORAGE_DIRECTORY_PATH, memberId, dailryId), findPage.getId().toString());
         findPage.updateThumbnail(fileUrl);
     }

--- a/backend/src/main/java/com/daily/daily/post/service/PostService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostService.java
@@ -1,6 +1,7 @@
 package com.daily.daily.post.service;
 
 import com.daily.daily.common.exception.UnauthorizedAccessException;
+import com.daily.daily.common.domain.DirectoryPath;
 import com.daily.daily.common.service.S3StorageService;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.member.exception.MemberNotFoundException;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.net.URI;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
@@ -27,8 +29,6 @@ import java.util.List;
 @Transactional
 @RequiredArgsConstructor
 public class PostService {
-
-    private final String POST_STORAGE_DIRECTORY_PATH = "post/" + LocalDate.now(ZoneId.of("Asia/Seoul"));
 
     private final PostRepository postRepository;
 
@@ -70,8 +70,11 @@ public class PostService {
     }
 
     private void uploadPageImage(Post post, MultipartFile pageImage) {
-        String fileUrl = storageService.uploadImage(pageImage, POST_STORAGE_DIRECTORY_PATH, post.getId().toString());
-        post.updatePageImage(fileUrl);
+        DirectoryPath dirPath = DirectoryPath.of("post", LocalDate.now(ZoneId.of("Asia/Seoul")).toString());
+
+        URI fileUri = storageService.uploadImage(pageImage, dirPath, post.getId().toString() + ".png");
+
+        post.updatePageImage(fileUri.toString());
     }
 
     public PostReadResponseDTO find(Long postId) {

--- a/backend/src/main/java/com/daily/daily/post/service/PostService.java
+++ b/backend/src/main/java/com/daily/daily/post/service/PostService.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -70,9 +71,11 @@ public class PostService {
     }
 
     private void uploadPageImage(Post post, MultipartFile pageImage) {
-        DirectoryPath dirPath = DirectoryPath.of("post", LocalDate.now(ZoneId.of("Asia/Seoul")).toString());
+        DirectoryPath dirPath = DirectoryPath.of("post",
+                LocalDate.now(ZoneId.of("Asia/Seoul")).toString(),
+                post.getId().toString());
 
-        URI fileUri = storageService.uploadImage(pageImage, dirPath, post.getId().toString() + ".png");
+        URI fileUri = storageService.uploadImage(pageImage, dirPath, UUID.randomUUID() + ".png");
 
         post.updatePageImage(fileUri.toString());
     }

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -599,8 +599,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5OTUyNzkzfQ.pwM-qN2YQLZGRx0n4w2NEzqipZewo2Fyl65W10wfys41SdJsTntn6fq0Ln4RqqVBgZ6jgRnAJHQA0Qe31nVsqQ; Path=/; Domain=localhost; Secure; HttpOnly; SameSite=None
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcwOTcxODU1OSwiZXhwIjoxOTQzOTUyNzkzfQ.1hQlHBI1aW83FA9NIzofM5-MkFVfjf69gXCZGVcHTKfMzP4fiBkBkAwsn-m_T2wcqZaO8zs5sFp9f-4P_6VrNg; Path=/; Domain=localhost; Secure; HttpOnly; SameSite=None
+Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxMiwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzEwMzcyMjg4fQ.RO7N_iTUTltpNt5i12z9aWRkrQAsYBTHhxEi4e6tiTmAmeXa_yXaDhQPy4SLLnWqw81al9VGDQtkHHKWBlPVnA; Path=/; Domain=localhost; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTIsImlhdCI6MTcxMDEzODA1NCwiZXhwIjoxOTQ0MzcyMjg4fQ.vtpYBaV4fVI9QDHyXrCGolee8eQvdaShpfE5gQX6BogDORWcoJID_aaUYTT6xyqUswbl4u2V7smtpNdEgIZ0cQ; Path=/; Domain=localhost; Secure; HttpOnly; SameSite=None
 Content-Type: application/json
 
 {
@@ -619,8 +619,8 @@ Content-Type: application/json
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/logout HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDk5NTI3OTJ9.NwogX239UTsQ-tcXXFFMtCu6z7eXoq6rW3VE03BAi2PUiUuyaaXzAGv9HR1OY5ZFLSidssvZ9koWA7ly5SK43w
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA5NzE4NTU4LCJleHAiOjE5NDM5NTI3OTJ9._16-kRlFpSe1BuPyE4mvfHIPLA27HNMx7aKEb05mbpXLNZOAU68aVdjcAVBoEYmv52_Am_7LMro1NkUZqJ5txA</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MTAzNzIyODZ9.QxsEmQciORASHnN2Hp3LcpqhgWOY9SDMU2uThX9JZtKI68rgqLM8Y3BeTjQ3B0cgQg9gd31GaloukPXAbVowKA
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzEwMTM4MDUyLCJleHAiOjE5NDQzNzIyODZ9.VZvvEe7OKbIiW8yC1pjlmzVcpkuruos8rpcBgXpFSIk8Cq4988S5GzoBxspnePBPIMtksw3a69ulziGD5-qbDQ</code></pre>
 </div>
 </div>
 </div>
@@ -649,8 +649,8 @@ Content-Type: application/json
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/token HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo0LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDk5NTI3OTJ9.A-xKJk9_Lx_2ZXi_3KGzMtrmccQm2_u5ERzp0gIHU4aKORKHPq1rQ0wJixmcjGyUEpBogsgzVpMzhPp1IF3H5A
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzA5NzE4NTU4LCJleHAiOjE5NDM5NTI3OTJ9.T--T2t5bEXf9mIJcX6xnjVwKxfyXRFDCYYGzB0z5_hMcGoznwmMbvYn5x2JSla5Phq16s65jfBnUkCr5NI9q5g</code></pre>
+Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo0LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MTAzNzIyODd9.QpX-Gkk0FPAp6lrQ4dTjxuCXjENqrS_sOiriVZc8SbOnelI-5lWPIMbnFsBnYql6UuwibepuIx_vY18EBgWutQ
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6NCwiaWF0IjoxNzEwMTM4MDUzLCJleHAiOjE5NDQzNzIyODd9.pmjqfM1KHwq9BaMgtm5Gl2qdi_luLMbB4e1G9s11_46p2VlNNeuo1oCtTjT6BKakC_RvipIo6iSuySSit54WWg</code></pre>
 </div>
 </div>
 </div>
@@ -1962,7 +1962,7 @@ dailryPage
 Content-Disposition: form-data; name=dailryPageRequest; filename=dailryPageRequest
 Content-Type: application/json
 
-{"background":"무지","elements":[{"id":"asdf","type":"textBox","order":1,"position":{"x":100,"y":50},"size":{"width":200,"height":100},"rotation":"90deg","typeContent":{"backgroundColor":"#ffcc00","color":"#333333","fontSize":12,"text":"아 어지럽다.","fontWeight":"bold","font":"굴림"}},{"id":"123avxsdf","type":"drawing","order":3,"position":{"x":100,"y":50},"size":{"width":250,"height":150},"rotation":"60deg","typeContent":{"base64":"YXNjc2FzYXZmbnJ0bnJ0bnN0"}},{"id":"123a21233df","type":"sticker","order":5,"position":{"x":110,"y":50},"size":{"width":300,"height":150},"rotation":"45deg","typeContent":{"imageUrl":"https://trboard.game.onstove.com/Data/TR/20180111/13/636512725318200105.jpg"}}]}
+{"background":"무지","deletedElementIds":["aba113a"],"elements":[{"id":"asdf","type":"textBox","order":1,"position":{"x":100,"y":50},"size":{"width":200,"height":100},"rotation":"90deg","typeContent":{"backgroundColor":"#ffcc00","color":"#333333","fontSize":12,"text":"아 어지럽다.","fontWeight":"bold","font":"굴림"}},{"id":"123avxsdf","type":"drawing","order":3,"position":{"x":100,"y":50},"size":{"width":250,"height":150},"rotation":"60deg","typeContent":{"base64":"YXNjc2FzYXZmbnJ0bnJ0bnN0"}},{"id":"123a21233df","type":"sticker","order":5,"position":{"x":110,"y":50},"size":{"width":300,"height":150},"rotation":"45deg","typeContent":{"imageUrl":"https://trboard.game.onstove.com/Data/TR/20180111/13/636512725318200105.jpg"}}]}
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
@@ -2028,6 +2028,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>background</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">다일리 페이지 배경</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>deletedElementIds</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">삭제할 element의 id 목록</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>elements</code></p></td>
@@ -3445,7 +3450,7 @@ Content-Type: application/json
 <div class="sect2">
 <h3 id="_인기게시글_여러건_조회">인기게시글 여러건 조회</h3>
 <div class="sect3">
-<h4 id="_요청_10">요청</h4>
+<h4 id="_요청_11">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/hotPosts?page=0&amp;size=5 HTTP/1.1</code></pre>
@@ -3479,7 +3484,7 @@ Content-Type: application/json
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_31">응답</h4>
+<h4 id="_응답_32">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3651,7 +3656,7 @@ Content-Type: */*;charset=UTF-8</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_응답_32">응답</h4>
+<h4 id="_응답_33">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3677,7 +3682,7 @@ Content-Type: */*;charset=UTF-8</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_응답_33">응답</h4>
+<h4 id="_응답_34">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3755,7 +3760,7 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_34">응답</h4>
+<h4 id="_응답_35">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
@@ -3886,7 +3891,7 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_35">응답</h4>
+<h4 id="_응답_36">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3961,7 +3966,7 @@ Content-Type: application/json
 <div class="sect2">
 <h3 id="_댓글_조회">댓글 조회</h3>
 <div class="sect3">
-<h4 id="_요청_11">요청</h4>
+<h4 id="_요청_12">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/posts/31/comments?page=0&amp;size=3 HTTP/1.1</code></pre>
@@ -4014,7 +4019,7 @@ Content-Type: application/json
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_36">응답</h4>
+<h4 id="_응답_37">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4134,7 +4139,7 @@ Content-Type: application/json
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_37">응답</h4>
+<h4 id="_응답_38">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4154,7 +4159,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-06 18:48:55 +0900
+Last updated 2024-03-06 19:44:55 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/daily/daily/common/file_save/DirectoryPathTest.java
+++ b/backend/src/test/java/com/daily/daily/common/file_save/DirectoryPathTest.java
@@ -1,0 +1,21 @@
+package com.daily.daily.common.file_save;
+
+import com.daily.daily.common.domain.DirectoryPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DirectoryPathTest {
+
+    @Test
+    @DisplayName("DirectoryPath의 path는 '/'로 시작해야한다. 그리고 끝에는 '/'가 존재하지 않는다")
+    void test1() {
+        DirectoryPath directoryPath = DirectoryPath.of("dir1", "dir2", "dir3");
+
+        String path = directoryPath.getPath();
+
+        assertThat(path).startsWith("/");
+        assertThat(path).doesNotEndWith("/");
+    }
+}

--- a/backend/src/test/java/com/daily/daily/common/service/S3StorageServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/common/service/S3StorageServiceTest.java
@@ -1,5 +1,6 @@
 package com.daily.daily.common.service;
 
+import com.daily.daily.common.domain.DirectoryPath;
 import com.daily.daily.common.exception.FileContentTypeUnmatchedException;
 import io.awspring.cloud.s3.S3Operations;
 import org.junit.jupiter.api.DisplayName;
@@ -11,11 +12,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 
+import java.net.URI;
+
+import static com.daily.daily.dailrypage.fixture.DailryPageFixture.다일리_페이지_섬네일_파일;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(MockitoExtension.class)
 class S3StorageServiceTest {
-
     @Mock
     S3Operations s3Operations;
     @InjectMocks
@@ -32,7 +36,20 @@ class S3StorageServiceTest {
         );
 
         //when, then
-        assertThatThrownBy(() -> s3StorageService.uploadImage(textFile, "post/", ""))
+        assertThatThrownBy(() -> s3StorageService.uploadImage(textFile, DirectoryPath.of("post"), ""))
                 .isInstanceOf(FileContentTypeUnmatchedException.class);
+    }
+
+    @Test
+    @DisplayName("파일 업로드 후 반환하는 URI의 포맷이 올바른지 확인한다.")
+    void uploadImageURIFormatTest() {
+        //given, when
+        URI uri = s3StorageService.uploadImage(다일리_페이지_섬네일_파일(),
+                DirectoryPath.of("thumbnail", "31", "22"),
+                "41");
+
+        //then
+        assertThat(uri.getPath()).isEqualTo("/thumbnail/31/22/41");
+        assertThat(uri.toString()).startsWith("https://");
     }
 }

--- a/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
@@ -23,7 +23,6 @@ import static com.daily.daily.dailrypage.fixture.DailryPageFixture.*;
 import static com.daily.daily.testutil.document.RestDocsUtil.document;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.description;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
@@ -74,7 +73,7 @@ class DailryPageControllerTest {
             perform.andExpect(status().isCreated())
                     .andDo(print())
                     .andExpect(jsonPath("$.dailryId").value(DAILRY_ID))
-                    .andExpect(jsonPath("$.pageId").value(DAILRY_PAGE_ID))
+                    .andExpect(jsonPath("$.pageId").value(다일리페이지_ID))
                     .andExpect(jsonPath("$.background").value("grid"))
                     .andExpect(jsonPath("$.pageNumber").value(1));
 
@@ -101,7 +100,7 @@ class DailryPageControllerTest {
             given(dailryPageService.update(any(), any(), any(), any())).willReturn(다일리_페이지_응답_DTO());
 
             //when
-            ResultActions perform = mockMvc.perform(multipart("/api/dailry/pages/{pageId}/edit", DAILRY_PAGE_ID)
+            ResultActions perform = mockMvc.perform(multipart("/api/dailry/pages/{pageId}/edit", 다일리페이지_ID)
                     .file(다일리_페이지_섬네일_파일())
                     .file(다일리_페이지_요청_DTO_JSON_파일())
                     .contentType(MULTIPART_FORM_DATA)
@@ -111,7 +110,7 @@ class DailryPageControllerTest {
             //then
             perform.andExpect(status().isOk())
                     .andDo(print())
-                    .andExpect(jsonPath("$.pageId").value(DAILRY_PAGE_ID))
+                    .andExpect(jsonPath("$.pageId").value(다일리페이지_ID))
                     .andExpect(jsonPath("$.background").value("무지"))
                     .andExpect(jsonPath("$.pageNumber").value(1))
                     .andExpect(jsonPath("$.thumbnail").value("https://data.da-ily.site/thumbnail/5/1/awefkaweop"))
@@ -171,14 +170,14 @@ class DailryPageControllerTest {
             given(dailryPageService.find(any(), any())).willReturn(다일리_페이지_응답_DTO());
 
             //when
-            ResultActions perform = mockMvc.perform(get("/api/dailry/pages/{pageId}", DAILRY_PAGE_ID)
+            ResultActions perform = mockMvc.perform(get("/api/dailry/pages/{pageId}", 다일리페이지_ID)
                     .with(csrf().asHeader())
             );
 
             //then
             perform.andExpect(status().isOk())
                     .andDo(print())
-                    .andExpect(jsonPath("$.pageId").value(DAILRY_PAGE_ID))
+                    .andExpect(jsonPath("$.pageId").value(다일리페이지_ID))
                     .andExpect(jsonPath("$.background").value("무지"))
                     .andExpect(jsonPath("$.pageNumber").value(1))
                     .andExpect(jsonPath("$.thumbnail").value("https://data.da-ily.site/thumbnail/5/1/awefkaweop"))
@@ -220,7 +219,7 @@ class DailryPageControllerTest {
             given(dailryPageService.findAll(any(), any())).willReturn(다일리_페이지_미리보기_DTO());
 
             //when
-            ResultActions perform = mockMvc.perform(get("/api/dailry/{dailryId}/pages", DAILRY_PAGE_ID)
+            ResultActions perform = mockMvc.perform(get("/api/dailry/{dailryId}/pages", 다일리페이지_ID)
                     .with(csrf().asHeader())
             );
 
@@ -253,7 +252,7 @@ class DailryPageControllerTest {
         @WithMockUser
         @DisplayName("다일리 페이지 삭제가 성공했을 때 응답결과를 검사한다.")
         void test1() throws Exception {
-            ResultActions perform = mockMvc.perform(delete("/api/dailry/pages/{pageId}", DAILRY_PAGE_ID)
+            ResultActions perform = mockMvc.perform(delete("/api/dailry/pages/{pageId}", 다일리페이지_ID)
                     .with(csrf().asHeader())
             );
 

--- a/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/controller/DailryPageControllerTest.java
@@ -128,6 +128,7 @@ class DailryPageControllerTest {
                     relaxedRequestPartFields(
                             "dailryPageRequest",
                             fieldWithPath("background").type(STRING).description("다일리 페이지 배경"),
+                            fieldWithPath("deletedElementIds").type(ARRAY).description("삭제할 element의 id 목록"),
                             fieldWithPath("elements").type(ARRAY).description("페이지 elements 목록"),
                             fieldWithPath("elements[].id").type(STRING).description("element의 id"),
                             fieldWithPath("elements[].type").type(STRING).description("element의 type"),

--- a/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
@@ -60,6 +60,7 @@ public class DailryPageFixture {
         DailryPageUpdateDTO 다일리_페이지_수정요청_DTO = new DailryPageUpdateDTO();
 
         다일리_페이지_수정요청_DTO.setBackground("무지");
+        다일리_페이지_수정요청_DTO.setDeletedElementIds(List.of("aba113a"));
         다일리_페이지_수정요청_DTO.setElements(List.of(첫번째_elementsDTO(), 두번째_elementsDTO(), 세번째_elementsDTO()));
 
         return 다일리_페이지_수정요청_DTO;

--- a/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
@@ -35,6 +35,18 @@ public class DailryPageFixture {
         ReflectionTestUtils.setField(비어있는_다일리_페이지, "id", 다일리페이지_ID);
         return 비어있는_다일리_페이지;
     }
+
+    public static DailryPage 다일리_페이지() {
+        DailryPage 다일리_페이지 = DailryPage.builder()
+                .pageNumber(1)
+                .dailry(일반회원1이_작성한_2번째_다일리())
+                .build();
+
+        다일리_페이지.addOrUpdateElements(다일리_페이지_수정요청_DTO().getElements());
+        ReflectionTestUtils.setField(다일리_페이지, "id", 다일리페이지_ID);
+
+        return 다일리_페이지;
+    }
     public static DailryPageCreateResponseDTO 비어있는_다일리_페이지_DTO() {
         return DailryPageCreateResponseDTO.builder()
                 .dailryId(DAILRY_ID)
@@ -93,7 +105,7 @@ public class DailryPageFixture {
         return 다일리_페이지_미리보기_DTO;
     }
 
-    private static DailryPageUpdateDTO.ElementDTO 첫번째_elementsDTO() {
+    public static DailryPageUpdateDTO.ElementDTO 첫번째_elementsDTO() {
         DailryPageUpdateDTO.ElementDTO 첫번째_elementsDTO = new DailryPageUpdateDTO.ElementDTO();
 
         첫번째_elementsDTO.setId("asdf");
@@ -116,7 +128,7 @@ public class DailryPageFixture {
         return 첫번째_elementsDTO;
     }
 
-    private static DailryPageUpdateDTO.ElementDTO 두번째_elementsDTO() {
+    public static DailryPageUpdateDTO.ElementDTO 두번째_elementsDTO() {
         DailryPageUpdateDTO.ElementDTO 두번째_elementsDTO = new DailryPageUpdateDTO.ElementDTO();
         두번째_elementsDTO.setId("123avxsdf");
         두번째_elementsDTO.setType("drawing");
@@ -133,7 +145,7 @@ public class DailryPageFixture {
         return 두번째_elementsDTO;
     }
 
-    private static DailryPageUpdateDTO.ElementDTO 세번째_elementsDTO() {
+    public static DailryPageUpdateDTO.ElementDTO 세번째_elementsDTO() {
         DailryPageUpdateDTO.ElementDTO 세번째_elementsDTO = new DailryPageUpdateDTO.ElementDTO();
         세번째_elementsDTO.setId("123a21233df");
         세번째_elementsDTO.setType("sticker");

--- a/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/fixture/DailryPageFixture.java
@@ -1,11 +1,13 @@
 package com.daily.daily.dailrypage.fixture;
 
+import com.daily.daily.dailrypage.domain.DailryPage;
 import com.daily.daily.dailrypage.dto.DailryPageCreateResponseDTO;
 import com.daily.daily.dailrypage.dto.DailryPageDTO;
 import com.daily.daily.dailrypage.dto.DailryPagePreviewDTO;
 import com.daily.daily.dailrypage.dto.DailryPageThumbnailDTO;
 import com.daily.daily.dailrypage.dto.DailryPageUpdateDTO;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -14,19 +16,29 @@ import java.util.List;
 import java.util.Map;
 
 import static com.daily.daily.dailry.fixture.DailryFixture.DAILRY_ID;
+import static com.daily.daily.dailry.fixture.DailryFixture.일반회원1이_작성한_2번째_다일리;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
 
 public class DailryPageFixture {
 
-    public static final Long DAILRY_PAGE_ID = 5L;
+    public static final Long 다일리페이지_ID = 5L;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    public static DailryPage 비어있는_다일리_페이지() {
+        DailryPage 비어있는_다일리_페이지 = DailryPage.builder()
+                .pageNumber(1)
+                .dailry(일반회원1이_작성한_2번째_다일리())
+                .build();
+
+        ReflectionTestUtils.setField(비어있는_다일리_페이지, "id", 다일리페이지_ID);
+        return 비어있는_다일리_페이지;
+    }
     public static DailryPageCreateResponseDTO 비어있는_다일리_페이지_DTO() {
         return DailryPageCreateResponseDTO.builder()
                 .dailryId(DAILRY_ID)
-                .pageId(DAILRY_PAGE_ID)
+                .pageId(다일리페이지_ID)
                 .background("grid")
                 .pageNumber(1L)
                 .build();
@@ -61,7 +73,7 @@ public class DailryPageFixture {
 
     public static DailryPageDTO 다일리_페이지_응답_DTO() {
         return DailryPageDTO.builder()
-                .pageId(DAILRY_PAGE_ID)
+                .pageId(다일리페이지_ID)
                 .background("무지")
                 .thumbnail("https://data.da-ily.site/thumbnail/5/1/awefkaweop")
                 .pageNumber(1)

--- a/backend/src/test/java/com/daily/daily/dailrypage/service/DailryPageServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/service/DailryPageServiceTest.java
@@ -1,0 +1,96 @@
+package com.daily.daily.dailrypage.service;
+
+import com.daily.daily.common.service.file_save.S3StorageService;
+import com.daily.daily.dailry.repository.DailryRepository;
+import com.daily.daily.dailrypage.domain.DailryPage;
+import com.daily.daily.dailrypage.dto.DailryPageDTO;
+import com.daily.daily.dailrypage.dto.DailryPageUpdateDTO;
+import com.daily.daily.dailrypage.repository.DailryPageRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import static com.daily.daily.dailrypage.fixture.DailryPageFixture.다일리_페이지_섬네일_파일;
+import static com.daily.daily.dailrypage.fixture.DailryPageFixture.다일리_페이지_수정요청_DTO;
+import static com.daily.daily.dailrypage.fixture.DailryPageFixture.다일리페이지_ID;
+import static com.daily.daily.dailrypage.fixture.DailryPageFixture.비어있는_다일리_페이지;
+import static com.daily.daily.member.fixture.MemberFixture.일반회원1_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DailryPageServiceTest {
+
+    @Mock
+    DailryPageRepository dailryPageRepository;
+
+    @Mock
+    DailryRepository dailryRepository;
+
+    @Mock
+    S3StorageService storageService;
+
+    @InjectMocks
+    DailryPageService dailryPageService;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+
+    @Nested
+    @DisplayName("DailryPageService/다일리 수정 메서드 테스트")
+    class update{
+        @Test
+        @DisplayName("다일리 수정 메서드가 호출될 때에는 반드시 썸네일을 업데이트 해야한다.")
+        void test1() {
+            //given
+            DailryPage 비어있는_다일리_페이지 = 비어있는_다일리_페이지();
+            MockMultipartFile 다일리_페이지_섬네일_파일 = 다일리_페이지_섬네일_파일();
+            DailryPageUpdateDTO 다일리_페이지_수정요청_dto = 다일리_페이지_수정요청_DTO();
+
+            when(dailryPageRepository.findById(any())).thenReturn(Optional.of(비어있는_다일리_페이지));
+
+            //when
+            dailryPageService.update(일반회원1_ID, 다일리페이지_ID, 다일리_페이지_수정요청_dto, 다일리_페이지_섬네일_파일);
+
+
+            //then
+            verify(storageService).uploadImage(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("다일리 수정 메서드에서 elements를 올바르게 추가하는지 테스트한다.")
+        void test2() throws JsonProcessingException {
+            DailryPage 비어있는_다일리_페이지 = 비어있는_다일리_페이지();
+            MockMultipartFile 다일리_페이지_섬네일_파일 = 다일리_페이지_섬네일_파일();
+            DailryPageUpdateDTO 다일리_페이지_수정요청_dto = 다일리_페이지_수정요청_DTO();
+
+            when(dailryPageRepository.findById(any())).thenReturn(Optional.of(비어있는_다일리_페이지));
+
+            //when
+            DailryPageDTO updated = dailryPageService.update(일반회원1_ID, 다일리페이지_ID, 다일리_페이지_수정요청_dto, 다일리_페이지_섬네일_파일);
+
+            Object elements1 = updated.getElements();
+
+            HashMap<String, Object> map = (HashMap<String, Object>) elements1;
+
+            Assertions.assertThat(map).hasSize(3);
+        }
+        @Test
+        @DisplayName("다일리 수정 메서드에서 elements를 올바르게 삭제하는지 테스트한다.")
+        void test3() {
+
+        }
+    }
+}

--- a/backend/src/test/java/com/daily/daily/dailrypage/service/DailryPageServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/dailrypage/service/DailryPageServiceTest.java
@@ -1,14 +1,12 @@
 package com.daily.daily.dailrypage.service;
 
-import com.daily.daily.common.service.file_save.S3StorageService;
+import com.daily.daily.common.service.S3StorageService;
 import com.daily.daily.dailry.repository.DailryRepository;
 import com.daily.daily.dailrypage.domain.DailryPage;
 import com.daily.daily.dailrypage.dto.DailryPageDTO;
 import com.daily.daily.dailrypage.dto.DailryPageUpdateDTO;
 import com.daily.daily.dailrypage.repository.DailryPageRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,14 +16,21 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 
-import java.util.HashMap;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
+import static com.daily.daily.dailrypage.fixture.DailryPageFixture.다일리_페이지;
 import static com.daily.daily.dailrypage.fixture.DailryPageFixture.다일리_페이지_섬네일_파일;
 import static com.daily.daily.dailrypage.fixture.DailryPageFixture.다일리_페이지_수정요청_DTO;
 import static com.daily.daily.dailrypage.fixture.DailryPageFixture.다일리페이지_ID;
+import static com.daily.daily.dailrypage.fixture.DailryPageFixture.두번째_elementsDTO;
 import static com.daily.daily.dailrypage.fixture.DailryPageFixture.비어있는_다일리_페이지;
+import static com.daily.daily.dailrypage.fixture.DailryPageFixture.첫번째_elementsDTO;
 import static com.daily.daily.member.fixture.MemberFixture.일반회원1_ID;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,7 +54,7 @@ class DailryPageServiceTest {
 
 
     @Nested
-    @DisplayName("DailryPageService/다일리 수정 메서드 테스트")
+    @DisplayName("DailryPageService/다일리 페이지 수정 메서드 테스트")
     class update{
         @Test
         @DisplayName("다일리 수정 메서드가 호출될 때에는 반드시 썸네일을 업데이트 해야한다.")
@@ -60,10 +65,10 @@ class DailryPageServiceTest {
             DailryPageUpdateDTO 다일리_페이지_수정요청_dto = 다일리_페이지_수정요청_DTO();
 
             when(dailryPageRepository.findById(any())).thenReturn(Optional.of(비어있는_다일리_페이지));
+            when(storageService.uploadImage(any(), any(), any())).thenReturn(URI.create(""));
 
             //when
             dailryPageService.update(일반회원1_ID, 다일리페이지_ID, 다일리_페이지_수정요청_dto, 다일리_페이지_섬네일_파일);
-
 
             //then
             verify(storageService).uploadImage(any(), any(), any());
@@ -71,26 +76,43 @@ class DailryPageServiceTest {
 
         @Test
         @DisplayName("다일리 수정 메서드에서 elements를 올바르게 추가하는지 테스트한다.")
-        void test2() throws JsonProcessingException {
+        void test2() {
+            //given
             DailryPage 비어있는_다일리_페이지 = 비어있는_다일리_페이지();
             MockMultipartFile 다일리_페이지_섬네일_파일 = 다일리_페이지_섬네일_파일();
             DailryPageUpdateDTO 다일리_페이지_수정요청_dto = 다일리_페이지_수정요청_DTO();
 
             when(dailryPageRepository.findById(any())).thenReturn(Optional.of(비어있는_다일리_페이지));
+            when(storageService.uploadImage(any(), any(), any())).thenReturn(URI.create(""));
 
             //when
-            DailryPageDTO updated = dailryPageService.update(일반회원1_ID, 다일리페이지_ID, 다일리_페이지_수정요청_dto, 다일리_페이지_섬네일_파일);
+            DailryPageDTO result = dailryPageService.update(일반회원1_ID, 다일리페이지_ID, 다일리_페이지_수정요청_dto, 다일리_페이지_섬네일_파일);
 
-            Object elements1 = updated.getElements();
-
-            HashMap<String, Object> map = (HashMap<String, Object>) elements1;
-
-            Assertions.assertThat(map).hasSize(3);
+            //then
+            Collection<Object> elements = result.getElements();
+            assertThat(elements).hasSize(3);
         }
         @Test
-        @DisplayName("다일리 수정 메서드에서 elements를 올바르게 삭제하는지 테스트한다.")
+        @DisplayName("다일리 수정 메서드에서 elements 를 올바르게 삭제하는지 테스트한다.")
         void test3() {
+            //given
+            DailryPageUpdateDTO 다일리_페이지_수정요청_dto = new DailryPageUpdateDTO();
 
+            List<String> deletedElementIds = new ArrayList<>();
+            deletedElementIds.add(첫번째_elementsDTO().getId());
+            deletedElementIds.add(두번째_elementsDTO().getId());
+
+            다일리_페이지_수정요청_dto.setDeletedElementIds(deletedElementIds);
+
+            when(dailryPageRepository.findById(any())).thenReturn(Optional.of(다일리_페이지()));
+            when(storageService.uploadImage(any(), any(), any())).thenReturn(URI.create(""));
+
+            //when
+            DailryPageDTO result = dailryPageService.update(일반회원1_ID, 다일리페이지_ID, 다일리_페이지_수정요청_dto, 다일리_페이지_섬네일_파일());
+
+            //then  3 - 2 = 1
+            Collection<Object> elements = result.getElements();
+            assertThat(elements).hasSize(1);
         }
     }
 }

--- a/backend/src/test/java/com/daily/daily/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/post/service/PostServiceTest.java
@@ -4,7 +4,6 @@ import com.daily.daily.common.exception.UnauthorizedAccessException;
 import com.daily.daily.common.service.S3StorageService;
 import com.daily.daily.member.repository.MemberRepository;
 import com.daily.daily.post.domain.Post;
-import com.daily.daily.post.dto.PostReadResponseDTO;
 import com.daily.daily.post.dto.PostWriteRequestDTO;
 import com.daily.daily.post.dto.PostWriteResponseDTO;
 import com.daily.daily.post.repository.PostLikeRepository;
@@ -18,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.net.URI;
 import java.util.HashSet;
 import java.util.Optional;
 
@@ -61,7 +61,7 @@ class PostServiceTest {
             Post 일반회원1이_작성한_게시글 = 일반회원1이_작성한_게시글();
 
             when(memberRepository.findById(any())).thenReturn(Optional.of(일반회원1()));
-            when(storageService.uploadImage(any(), any(), any())).thenReturn("post/3-awef-123-124-wafewe123123_asdf.png");
+            when(storageService.uploadImage(any(), any(), any())).thenReturn(URI.create("post/3-awef-123-124-wafewe123123_asdf.png"));
             when(postRepository.save(any())).thenReturn(일반회원1이_작성한_게시글);
 
             //when
@@ -99,7 +99,7 @@ class PostServiceTest {
         void test2() {
             //given
             when(postRepository.findById(POST_ID)).thenReturn(Optional.of(일반회원1이_작성한_게시글()));
-            when(storageService.uploadImage(any(), any(), any())).thenReturn("post/4-awef-1231-xcvsdf-12312_qwf.png");
+            when(storageService.uploadImage(any(), any(), any())).thenReturn(URI.create("post/4-awef-1231-xcvsdf-12312_qwf.png"));
 
             //when
             PostWriteResponseDTO updateResult = postService.update(일반회원1_ID, POST_ID, new PostWriteRequestDTO(), 다일리_페이지_이미지_파일());


### PR DESCRIPTION
## 연관 이슈
close: #276 
## 작업 내용
 - dailryPageRequest에 deletedElementIds 필드 추가
 - deletedElementIds의 id로 들어온 컴포넌트는 삭제한다.

**[ 리팩토링 ]**

- 다일리 페이지 썸네일 파일의 저장 경로를 바꾸었습니다.
    - thumbnail/{memberId}/{dailryId}/{pageId}.png 
    - 변경한 이유는 파일 경로나 이름에 시간 정보나 UUID가 있으면 썸네일 파일이 너무 많이 생길 것이 우려되어서 입니다.
    - 위와 같은 경로로 설정하면 덮어쓰기 방식으로 이미지를 저장하기 때문에 이미지 파일이 덜 생성됩니다.


 - S3StorageService 를 리팩토링 하였습니다.
     - 클라이언트 코드에서 파일 이름을 지정할 수 있도록 하였습니다.
     - 기존 코드는 S3StorageService에서 파일의 네이밍에 관여하였기에 유연하게 네이밍 전략을 짤 수 없었습니다.
     -  디렉토리 경로를 다루는 객체 DirectoryPath 를 추가하였습니다.
     - uploadImage() 메서드는 이제 String이 아니라 URI 객체를 반환하도록 하였습니다.


## 의논할 거리
## Merge 전에 해야할 작업
## 기타
