### PR TITLE
꾸미기 컴포넌트 추가, 수정 기능 버그 픽스 및 개선

### DIFF
--- a/frontend/src/components/da-ily/Moveable/Moveable.jsx
+++ b/frontend/src/components/da-ily/Moveable/Moveable.jsx
@@ -1,25 +1,20 @@
 import Moveable from 'react-moveable';
 import PropTypes from 'prop-types';
-import MoveableHelper from 'moveable-helper';
-import { useState } from 'react';
 
 const MoveableComponent = (props) => {
   const { target, setCommonProperty } = props;
-  const [helper] = useState(() => {
-    return new MoveableHelper();
-  });
 
   return (
     <Moveable
       target={target}
       draggable={true}
       resizable={true}
-      rotatable={true}
       throttleDrag={0}
       throttleResize={0}
       throttleRotate={0}
-      onDragStart={helper.onDragStart}
-      onDrag={helper.onDrag}
+      onRender={(e) => {
+        e.target.style.cssText += e.cssText;
+      }}
       onDragEnd={(e) => {
         if (e.isDrag) {
           const movedX = parseInt(e.lastEvent.translate[0], 10);
@@ -33,24 +28,20 @@ const MoveableComponent = (props) => {
           });
         }
       }}
-      onRotateStart={helper.onRotateStart}
-      onRotate={helper.onRotate}
       onRotateEnd={(e) => {
         const transformString = e.target.style.transform;
         const deg = transformString.split('rotate(')[1].split('deg')[0];
 
         setCommonProperty({ rotation: deg });
       }}
-      onResizeStart={helper.onResizeStart}
-      onResize={helper.onResize}
-      onResizeEnd={(e) =>
+      onResizeEnd={(e) => {
         setCommonProperty({
           size: {
-            width: e.target.style.width,
-            height: e.target.style.height,
+            width: e.lastEvent.width,
+            height: e.lastEvent.height,
           },
-        })
-      }
+        });
+      }}
     />
   );
 };

--- a/frontend/src/components/decorate/DecorateWrapper.jsx
+++ b/frontend/src/components/decorate/DecorateWrapper.jsx
@@ -7,14 +7,13 @@ const DecorateWrapper = forwardRef((props, ref) => {
     id,
     children,
     order,
-    position,
-    size,
-    rotation,
-    typeContent,
+    initialStyle,
     canEdit,
+    typeContent,
     onMouseDown,
     onMouseUp,
   } = props;
+  const { position, size, rotation } = initialStyle;
 
   return (
     <div
@@ -22,14 +21,18 @@ const DecorateWrapper = forwardRef((props, ref) => {
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
       ref={ref}
-      style={S.ElementStyle({
-        position,
-        typeContent,
-        order,
-        size,
-        canEdit,
-        rotation,
-      })}
+      style={{
+        top: `${position.y}px`,
+        left: `${position.x}px`,
+        width: `${size?.width}px`,
+        height: `${size?.height}px`,
+        rotate: `${rotation}deg`,
+        ...S.ElementStyle({
+          typeContent,
+          canEdit,
+          order,
+        }),
+      }}
     >
       {children}
     </div>
@@ -46,6 +49,7 @@ DecorateWrapper.propTypes = {
   setTarget: PropTypes.func,
   index: PropTypes.number,
   type: PropTypes.string,
+  initialStyle: PropTypes.object,
   position: PropTypes.object,
   typeContent: PropTypes.object,
   order: PropTypes.number,

--- a/frontend/src/components/decorate/TextBox/TextBox.jsx
+++ b/frontend/src/components/decorate/TextBox/TextBox.jsx
@@ -7,7 +7,7 @@ const TextBox = (props) => {
   const { typeContent, setTypeContent } = props;
 
   const [text, setText] = useState('');
-  const debouncedText = useDebounce(text, 500);
+  const debouncedText = useDebounce(text, 100);
   const textRef = useRef(null);
   const [height, setHeight] = useState(typeContent?.current?.scrollHeight);
 

--- a/frontend/src/hooks/useEditDecorateComponent.jsx
+++ b/frontend/src/hooks/useEditDecorateComponent.jsx
@@ -8,7 +8,7 @@ const useEditDecorateComponent = (
   const [canEditDecorateComponent, setCanEditDecorateComponent] =
     useState(null);
 
-  const [editMode, setEditMode] = useState('');
+  const [editMode, setEditMode] = useState(null);
 
   const isTypeContentEdited =
     editMode === EDIT_MODE.TYPE_CONTENT &&

--- a/frontend/src/hooks/useNewDecorateComponent/createNewDecorateComponent.jsx
+++ b/frontend/src/hooks/useNewDecorateComponent/createNewDecorateComponent.jsx
@@ -13,6 +13,7 @@ export const getCommonDecorateComponentProperties = (e, pageRef) => {
   return {
     ...commonDecorateComponentProperties,
     id: `decorate-component-${new Date().toISOString()}`,
+    position: getRelativePosition(e, pageRef),
     initialStyle: {
       ...commonDecorateComponentProperties.initialStyle,
       position: getRelativePosition(e, pageRef),

--- a/frontend/src/hooks/useNewDecorateComponent/createNewDecorateComponent.jsx
+++ b/frontend/src/hooks/useNewDecorateComponent/createNewDecorateComponent.jsx
@@ -13,6 +13,9 @@ export const getCommonDecorateComponentProperties = (e, pageRef) => {
   return {
     ...commonDecorateComponentProperties,
     id: `decorate-component-${new Date().toISOString()}`,
-    position: getRelativePosition(e, pageRef),
+    initialStyle: {
+      ...commonDecorateComponentProperties.initialStyle,
+      position: getRelativePosition(e, pageRef),
+    },
   };
 };

--- a/frontend/src/hooks/useNewDecorateComponent/properties.js
+++ b/frontend/src/hooks/useNewDecorateComponent/properties.js
@@ -5,6 +5,14 @@ export const commonDecorateComponentProperties = {
     width: 200,
     height: 150,
   },
+  initialStyle: {
+    position: { x: 0, y: 0 },
+    size: {
+      width: 200,
+      height: 150,
+    },
+    rotation: '0',
+  },
   position: {
     x: 0,
     y: 0,

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -166,17 +166,18 @@ const DailryPage = () => {
   };
 
   const handleClickPage = (e) => {
-    if (selectedTool === null) {
+    if (
+      selectedTool === null ||
+      (selectedTool === DECORATE_TYPE.MOVING && !canEditDecorateComponent)
+    ) {
       return;
     }
 
-    if (editMode === EDIT_MODE.COMMON_PROPERTY) {
-      if (canEditDecorateComponent) {
-        completeModifyDecorateComponent();
-        setTarget(null);
+    if (canEditDecorateComponent) {
+      completeModifyDecorateComponent();
+      setTarget(null);
 
-        setCanEditDecorateComponent(null);
-      }
+      setCanEditDecorateComponent(null);
       return;
     }
 

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -115,9 +115,10 @@ const DailryPage = () => {
         const datas = page.data?.elements.map((i) => ({
           ...i,
           initialStyle: {
-            position: i.position,
-            size: i.size,
-            rotation: i.rotation,
+            ...i.initialStyle,
+            position: i?.position,
+            size: i?.size,
+            rotation: i?.rotation,
           },
         }));
         setDecorateComponents(datas);

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -112,7 +112,15 @@ const DailryPage = () => {
       const page = await getPage(pageIds[pageNumber - 1]);
 
       if (page.data?.elements.length > 0) {
-        setDecorateComponents(page.data?.elements);
+        const datas = page.data?.elements.map((i) => ({
+          ...i,
+          initialStyle: {
+            position: i.position,
+            size: i.size,
+            rotation: i.rotation,
+          },
+        }));
+        setDecorateComponents(datas);
       }
     })();
   }, [pageIds, pageNumber]);
@@ -125,13 +133,6 @@ const DailryPage = () => {
       closeOnClick: true,
       transition: Zoom,
     });
-  };
-
-  const initializeMoveableStyle = () => {
-    const newStyleString = ` translate(0px, 0px) rotate(${canEditDecorateComponent?.rotation}deg) scale(1, 1) `;
-    moveableRef[target].style.transform = newStyleString;
-
-    setTarget(null);
   };
 
   const handleLeftArrowClick = () => {
@@ -171,7 +172,7 @@ const DailryPage = () => {
     if (editMode === EDIT_MODE.COMMON_PROPERTY) {
       if (canEditDecorateComponent) {
         completeModifyDecorateComponent();
-        initializeMoveableStyle();
+        setTarget(null);
 
         setCanEditDecorateComponent(null);
       }
@@ -194,7 +195,7 @@ const DailryPage = () => {
       canEditDecorateComponent.id !== element.id
     ) {
       completeModifyDecorateComponent();
-      initializeMoveableStyle();
+      setTarget(null);
       setCanEditDecorateComponent(null);
       return;
     }
@@ -213,9 +214,12 @@ const DailryPage = () => {
       canEditDecorateComponent &&
       canEditDecorateComponent.id !== element.id
     ) {
-      initializeMoveableStyle();
+      setTarget(null);
     }
   };
+  useEffect(() => {
+    console.log(canEditDecorateComponent);
+  }, [canEditDecorateComponent]);
 
   return (
     <S.FlexWrapper>
@@ -294,7 +298,7 @@ const DailryPage = () => {
               }
               if (canEditDecorateComponent) {
                 completeModifyDecorateComponent();
-                initializeMoveableStyle();
+                setTarget(null);
                 setCanEditDecorateComponent(null);
               }
               setSelectedTool(selectedTool === t ? null : t);
@@ -320,7 +324,7 @@ const DailryPage = () => {
               }
               if (canEditDecorateComponent) {
                 completeModifyDecorateComponent();
-                initializeMoveableStyle();
+                setTarget(null);
                 setCanEditDecorateComponent(null);
               }
               setSelectedTool(selectedTool === t ? null : t);
@@ -340,6 +344,7 @@ const DailryPage = () => {
               }
               if (t === 'save') {
                 const formData = getPageFormData(updatedDecorateComponents);
+                console.log(updatedDecorateComponents);
                 await patchPage(pageIds[pageNumber - 1], formData);
               }
             };

--- a/frontend/src/pages/DailryPage/DailryPage.styled.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.styled.jsx
@@ -46,15 +46,11 @@ export const NoCanvas = styled.div`
   }
 `;
 
-export const ElementStyle = ({ position, order, size, canEdit }) => {
+export const ElementStyle = ({ canEdit, order }) => {
   return {
     position: 'absolute',
-    left: `${position.x}px`,
-    top: `${position.y}px`,
-    width: `${size.width}px`,
-    height: `${size.height}px`,
-    zIndex: order,
     border: canEdit ? `2px dashed #74ABD9` : '',
+    order,
   };
 };
 


### PR DESCRIPTION
## 연관 이슈
close: #271 
## 작업 내용
- `Moveable` 컴포넌트 과 타겟 꾸미기 컴포넌트 스타일 동기화 방식 변경
   - `Moveable` 타겟이 변경될 때, 타겟의 스타일이 초기화 되지 않도록 수정
      - `on~~~Start`, `on~~~End` 메서드 제거 (타겟의 스타일이 초기화 되는 원인)
      - `onRender` 메서드 를 이용해 타겟 꾸미기 컴포넌트 스타일 을 동기화
- 서버에서 가져오는 `공통 속성` 과 실제 `Moveable` 컴포넌트의 메서드로 인해 바뀌는 꾸미기 컴포넌트 의 `공통 속성` 을 분리 
   - `initialStyle`
       - 서버에서 가져오는 `공통 속성`.
       - 다일리 페이지 데이터를 fetch 할 때, 각 꾸미기 컴포넌트의 `공통 속성` 을 해당 속성에 할당하는 프로세스 추가
   - `position`, `size`, `rotation`
       - 기존 공통 속성 에 속하던 속성 그대로 사용.
       - 실제 `Moveable` 컴포넌트 의 타겟 이 되어 바뀌는 값은 이 값들.
## 의논할 거리
- 현재 꾸미기 컴포넌트의 공통 속성 이 서버에서 오는 것과 클라이언트에서 조정하는 것이 나누어져 있는데, 통합하거나 효과적으로 분리하는 것이 나을 것 같습니다.
## Merge 전에 해야할 작업
## 기타
