### PR TITLE
꾸미기 컴포넌트 삭제

### DIFF
--- a/frontend/src/components/decorate/DeleteButton/DeleteButton.styled.jsx
+++ b/frontend/src/components/decorate/DeleteButton/DeleteButton.styled.jsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const DecorateComponentDeleteButton = styled.button`
+  position: absolute;
+  top: -20px;
+  right: 0px;
+  text-decoration: underline;
+  color: red;
+`;

--- a/frontend/src/hooks/usePageData.jsx
+++ b/frontend/src/hooks/usePageData.jsx
@@ -12,12 +12,16 @@ const usePageData = () => {
     setThumbnail(e.target.files[0]);
   };
 
-  const convertDecorateComponentsToBlob = (updatedDecorateComponents) => {
+  const convertDecorateComponentsToBlob = (
+    updatedDecorateComponents,
+    deletedElementIds,
+  ) => {
     const blob = new Blob(
       [
         JSON.stringify({
           background: '무지 테스트',
           elements: updatedDecorateComponents,
+          deletedElementIds,
         }),
       ],
       { type: 'application/json' },
@@ -26,11 +30,14 @@ const usePageData = () => {
     return blob;
   };
 
-  const getPageFormData = (updatedDecorateComponents) => {
+  const getPageFormData = (updatedDecorateComponents, deletedElementIds) => {
     formData.append('thumbnail', thumbnail);
     formData.append(
       'dailryPageRequest',
-      convertDecorateComponentsToBlob(updatedDecorateComponents),
+      convertDecorateComponentsToBlob(
+        updatedDecorateComponents,
+        deletedElementIds,
+      ),
     );
 
     return formData;

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -23,6 +23,7 @@ import useUpdatedDecorateComponents from '../../hooks/useUpdatedDecorateComponen
 import { TEXT } from '../../styles/color';
 import MoveableComponent from '../../components/da-ily/Moveable/Moveable';
 import usePageData from '../../hooks/usePageData';
+import { DecorateComponentDeleteButton } from '../../components/decorate/DeleteButton/DeleteButton.styled';
 
 const DailryPage = () => {
   const pageRef = useRef(null);
@@ -83,6 +84,19 @@ const DailryPage = () => {
   const isMoveable = () => target && editMode === EDIT_MODE.COMMON_PROPERTY;
 
   const { dailryId, pageId, pageIds, pageNumber } = currentDailry;
+
+  const [deletedDecorateComponentIds, setDeletedDecorateComponentIds] =
+    useState([]);
+
+  const deleteDecorateComponent = (id) => {
+    if (!deletedDecorateComponentIds.some((d) => d.id === id)) {
+      setDeletedDecorateComponentIds((prev) => [...prev, id]);
+    }
+
+    setDecorateComponents((prev) => prev.filter((p) => p.id !== id));
+
+    setTarget(null);
+  };
 
   useEffect(() => {
     (async () => {
@@ -252,6 +266,15 @@ const DailryPage = () => {
                 }}
                 {...element}
               >
+                {target !== null && target === index + 1 && (
+                  <DecorateComponentDeleteButton
+                    onClick={() => {
+                      deleteDecorateComponent(element.id);
+                    }}
+                  >
+                    삭제
+                  </DecorateComponentDeleteButton>
+                )}
                 <TypedDecorateComponent
                   type={element.type}
                   typeContent={element.typeContent}
@@ -345,8 +368,10 @@ const DailryPage = () => {
                 await handleDownloadClick();
               }
               if (t === 'save') {
-                const formData = getPageFormData(updatedDecorateComponents);
-                console.log(updatedDecorateComponents);
+                const formData = getPageFormData(
+                  updatedDecorateComponents,
+                  deletedDecorateComponentIds,
+                );
                 await patchPage(pageIds[pageNumber - 1], formData);
               }
             };


### PR DESCRIPTION
## 연관 이슈
close: #284 
## 작업 내용
* 삭제 버튼 추가
   - `DeleteButton.styled.jsx`
* 삭제 시, 꾸미기 컴포넌트 `Id` 를 `삭제 Id 리스트` 에 추가, 클라이언트 에서 보여지는 꾸미기 컴포넌트 배열에서 제외
* 페이지 수정 시, 요청 Body 에 삭제 `Id 리스트` 포함
## 의논할 거리
* 삭제 버튼 UI
## Merge 전에 해야할 작업
## 기타
