### PR TITLE
페이지 수정 시, 페이지 썸네일 전송

### DIFF
--- a/frontend/src/components/decorate/DeleteButton/DeleteButton.styled.jsx
+++ b/frontend/src/components/decorate/DeleteButton/DeleteButton.styled.jsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const DecorateComponentDeleteButton = styled.button`
+  position: absolute;
+  top: -20px;
+  right: 0px;
+  text-decoration: underline;
+  color: red;
+`;

--- a/frontend/src/hooks/usePageData.jsx
+++ b/frontend/src/hooks/usePageData.jsx
@@ -1,16 +1,5 @@
-import { useState } from 'react';
-
 const usePageData = () => {
   const formData = new FormData();
-  const [thumbnail, setThumbnail] = useState(null);
-
-  const onUploadFile = (e) => {
-    if (!e.target.files) {
-      return;
-    }
-
-    setThumbnail(e.target.files[0]);
-  };
 
   const convertDecorateComponentsToBlob = (
     updatedDecorateComponents,
@@ -30,7 +19,11 @@ const usePageData = () => {
     return blob;
   };
 
-  const getPageFormData = (updatedDecorateComponents, deletedElementIds) => {
+  const appendPageDataToFormData = (
+    thumbnail,
+    updatedDecorateComponents,
+    deletedElementIds,
+  ) => {
     formData.append('thumbnail', thumbnail);
     formData.append(
       'dailryPageRequest',
@@ -39,11 +32,9 @@ const usePageData = () => {
         deletedElementIds,
       ),
     );
-
-    return formData;
   };
 
-  return { getPageFormData, onUploadFile };
+  return { appendPageDataToFormData, formData };
 };
 
 export default usePageData;

--- a/frontend/src/hooks/usePageData.jsx
+++ b/frontend/src/hooks/usePageData.jsx
@@ -12,12 +12,16 @@ const usePageData = () => {
     setThumbnail(e.target.files[0]);
   };
 
-  const convertDecorateComponentsToBlob = (updatedDecorateComponents) => {
+  const convertDecorateComponentsToBlob = (
+    updatedDecorateComponents,
+    deletedElementIds,
+  ) => {
     const blob = new Blob(
       [
         JSON.stringify({
           background: '무지 테스트',
           elements: updatedDecorateComponents,
+          deletedElementIds,
         }),
       ],
       { type: 'application/json' },
@@ -26,11 +30,14 @@ const usePageData = () => {
     return blob;
   };
 
-  const getPageFormData = (updatedDecorateComponents) => {
+  const getPageFormData = (updatedDecorateComponents, deletedElementIds) => {
     formData.append('thumbnail', thumbnail);
     formData.append(
       'dailryPageRequest',
-      convertDecorateComponentsToBlob(updatedDecorateComponents),
+      convertDecorateComponentsToBlob(
+        updatedDecorateComponents,
+        deletedElementIds,
+      ),
     );
 
     return formData;

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -23,6 +23,7 @@ import useUpdatedDecorateComponents from '../../hooks/useUpdatedDecorateComponen
 import { TEXT } from '../../styles/color';
 import MoveableComponent from '../../components/da-ily/Moveable/Moveable';
 import usePageData from '../../hooks/usePageData';
+import { DecorateComponentDeleteButton } from '../../components/decorate/DeleteButton/DeleteButton.styled';
 
 const DailryPage = () => {
   const pageRef = useRef(null);
@@ -83,6 +84,19 @@ const DailryPage = () => {
   const isMoveable = () => target && editMode === EDIT_MODE.COMMON_PROPERTY;
 
   const { dailryId, pageId, pageIds, pageNumber } = currentDailry;
+
+  const [deletedDecorateComponentIds, setDeletedDecorateComponentIds] =
+    useState([]);
+
+  const deleteDecorateComponent = (id) => {
+    if (!deletedDecorateComponentIds.some((d) => d.id === id)) {
+      setDeletedDecorateComponentIds((prev) => [...prev, id]);
+    }
+
+    setDecorateComponents((prev) => prev.filter((p) => p.id !== id));
+
+    setTarget(null);
+  };
 
   useEffect(() => {
     (async () => {
@@ -252,6 +266,15 @@ const DailryPage = () => {
                 }}
                 {...element}
               >
+                {target !== null && target === index + 1 && (
+                  <DecorateComponentDeleteButton
+                    onClick={() => {
+                      deleteDecorateComponent(element.id);
+                    }}
+                  >
+                    삭제
+                  </DecorateComponentDeleteButton>
+                )}
                 <TypedDecorateComponent
                   type={element.type}
                   typeContent={element.typeContent}
@@ -345,8 +368,10 @@ const DailryPage = () => {
                 await handleDownloadClick();
               }
               if (t === 'save') {
-                const formData = getPageFormData(updatedDecorateComponents);
-                console.log(updatedDecorateComponents);
+                const formData = getPageFormData(
+                  updatedDecorateComponents,
+                  deletedDecorateComponentIds,
+                );
                 await patchPage(pageIds[pageNumber - 1], formData);
               }
             };

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -43,7 +43,7 @@ const DailryPage = () => {
     modifyUpdatedDecorateComponent,
   } = useUpdatedDecorateComponents();
 
-  const { getPageFormData, onUploadFile } = usePageData(
+  const { appendPageDataToFormData, formData } = usePageData(
     updatedDecorateComponents,
   );
 
@@ -169,9 +169,9 @@ const DailryPage = () => {
   const handleDownloadClick = async () => {
     try {
       const pageImg = await html2canvas(pageRef.current);
-      pageImg.toBlob((blob) => {
-        if (blob !== null) {
-          saveAs(blob, `dailry${dailryId}_${pageId}.png`);
+      pageImg.toBlob((pageImageBlob) => {
+        if (pageImageBlob !== null) {
+          saveAs(pageImageBlob, `dailry${dailryId}_${pageId}.png`);
         }
       });
     } catch (e) {
@@ -248,7 +248,6 @@ const DailryPage = () => {
 
       {havePage ? (
         <S.CanvasWrapper ref={pageRef} onMouseDown={handleClickPage}>
-          <input type="file" alt="what" onChange={onUploadFile} />
           {decorateComponents?.map((element, index) => {
             const canEdit =
               editMode === EDIT_MODE.TYPE_CONTENT &&
@@ -368,11 +367,16 @@ const DailryPage = () => {
                 await handleDownloadClick();
               }
               if (t === 'save') {
-                const formData = getPageFormData(
-                  updatedDecorateComponents,
-                  deletedDecorateComponentIds,
-                );
-                await patchPage(pageIds[pageNumber - 1], formData);
+                const pageImg = await html2canvas(pageRef.current);
+
+                pageImg.toBlob(async (pageImageBlob) => {
+                  appendPageDataToFormData(
+                    pageImageBlob,
+                    updatedDecorateComponents,
+                    deletedDecorateComponentIds,
+                  );
+                  await patchPage(pageIds[pageNumber - 1], formData);
+                });
               }
             };
             return (


### PR DESCRIPTION
## 연관 이슈
close: #281 
## 작업 내용
* `appendPageDataToFormData`
   - 기존 `getPageFormData` 함수명 변경
   - `페이지 수정 API` 호출 Body 에 들어갈 FormData 에 썸네일 포함
* 페이지 이미지 를 blob 으로 변환하는 toBlob 함수의 콜백함수 에서 페이지 수정 API 를 호출하도록 수정
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
