### PR TITLE
다일리 페이지 관련 버그 수정

### DIFF
--- a/frontend/src/hooks/useUpdatedDecorateComponents.jsx
+++ b/frontend/src/hooks/useUpdatedDecorateComponents.jsx
@@ -28,6 +28,7 @@ const useUpdatedDecorateComponents = () => {
   };
 
   return {
+    setUpdatedDecorateComponents,
     updatedDecorateComponents,
     addUpdatedDecorateComponent,
     modifyUpdatedDecorateComponent,

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -163,6 +163,8 @@ const DailryPage = () => {
       );
       await patchPage(pageIds[pageNumber - 1], formData);
     });
+
+    setUpdatedDecorateComponents([]);
   };
 
   const handleLeftArrowClick = async () => {

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -151,20 +151,23 @@ const DailryPage = () => {
     });
   };
 
-  const patchPageData = async () => {
+  const patchPageData = () => {
     setTarget(null);
-    const pageImg = await html2canvas(pageRef.current);
 
-    pageImg.toBlob(async (pageImageBlob) => {
-      appendPageDataToFormData(
-        pageImageBlob,
-        updatedDecorateComponents,
-        deletedDecorateComponentIds,
-      );
-      await patchPage(pageIds[pageNumber - 1], formData);
-    });
+    setTimeout(async () => {
+      const pageImg = await html2canvas(pageRef.current);
 
-    setUpdatedDecorateComponents([]);
+      pageImg.toBlob(async (pageImageBlob) => {
+        appendPageDataToFormData(
+          pageImageBlob,
+          updatedDecorateComponents,
+          deletedDecorateComponentIds,
+        );
+        await patchPage(pageIds[pageNumber - 1], formData);
+      });
+
+      setUpdatedDecorateComponents([]);
+    }, 100);
   };
 
   const handleLeftArrowClick = async () => {
@@ -192,7 +195,7 @@ const DailryPage = () => {
         '저장 하지 않은 꾸미기 컴포넌트가 존재합니다. 저장하시겠습니까?',
       )
     ) {
-      await patchPageData();
+      patchPageData();
     }
 
     setUpdatedDecorateComponents([]);
@@ -225,7 +228,7 @@ const DailryPage = () => {
         '저장 하지 않은 꾸미기 컴포넌트가 존재합니다. 저장하시겠습니까?',
       )
     ) {
-      await patchPageData();
+      patchPageData();
     }
     setUpdatedDecorateComponents([]);
 
@@ -451,7 +454,7 @@ const DailryPage = () => {
                     '저장 하지 않은 꾸미기 컴포넌트가 존재합니다. 저장하시겠습니까?',
                   )
                 ) {
-                  await patchPageData();
+                  patchPageData();
                 }
                 setUpdatedDecorateComponents([]);
                 const response = await postPage(dailryId);
@@ -465,7 +468,7 @@ const DailryPage = () => {
                 await handleDownloadClick();
               }
               if (t === 'save') {
-                await patchPageData();
+                patchPageData();
               }
             };
             return (

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -431,6 +431,27 @@ const DailryPage = () => {
                 setSelectedTool(null);
               }, 150);
               if (t === 'add') {
+                if (canEditDecorateComponent) {
+                  completeModifyDecorateComponent();
+                  setTarget(null);
+
+                  setCanEditDecorateComponent(null);
+                  return;
+                }
+
+                if (newDecorateComponent) {
+                  completeCreateNewDecorateComponent();
+                  return;
+                }
+                if (
+                  updatedDecorateComponents.length > 0 &&
+                  window.confirm(
+                    '저장 하지 않은 꾸미기 컴포넌트가 존재합니다. 저장하시겠습니까?',
+                  )
+                ) {
+                  await patchPageData();
+                }
+                setUpdatedDecorateComponents([]);
                 const response = await postPage(dailryId);
                 setCurrentDailry({
                   ...currentDailry,

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -206,6 +206,11 @@ const DailryPage = () => {
   const handleClickDecorate = (e, index, element) => {
     e.stopPropagation();
 
+    if (selectedTool === DECORATE_TYPE.MOVING) {
+      console.log('hell yeah');
+      setTarget(index + 1);
+    }
+
     if (
       canEditDecorateComponent &&
       canEditDecorateComponent.id !== element.id
@@ -216,15 +221,18 @@ const DailryPage = () => {
       return;
     }
 
-    setTarget(index + 1);
-
     if (newDecorateComponent) {
       completeCreateNewDecorateComponent();
 
       return;
     }
 
-    setCanEditDecorateComponent(element);
+    if (
+      editMode === EDIT_MODE.COMMON_PROPERTY ||
+      (editMode === EDIT_MODE.TYPE_CONTENT && selectedTool === element.type)
+    ) {
+      setCanEditDecorateComponent(element);
+    }
 
     if (
       canEditDecorateComponent &&
@@ -265,7 +273,8 @@ const DailryPage = () => {
                 }}
                 {...element}
               >
-                {target !== null && target === index + 1 && (
+                {(target === index + 1 ||
+                  canEditDecorateComponent?.id === element.id) && (
                   <DecorateComponentDeleteButton
                     onClick={() => {
                       deleteDecorateComponent(element.id);
@@ -274,6 +283,7 @@ const DailryPage = () => {
                     삭제
                   </DecorateComponentDeleteButton>
                 )}
+
                 <TypedDecorateComponent
                   type={element.type}
                   typeContent={element.typeContent}

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -367,6 +367,7 @@ const DailryPage = () => {
                 await handleDownloadClick();
               }
               if (t === 'save') {
+                setTarget(null);
                 const pageImg = await html2canvas(pageRef.current);
 
                 pageImg.toBlob(async (pageImageBlob) => {
@@ -377,7 +378,6 @@ const DailryPage = () => {
                   );
                   await patchPage(pageIds[pageNumber - 1], formData);
                 });
-
               }
             };
             return (


### PR DESCRIPTION
## 연관 이슈
## 작업 내용
* save 타입 버튼 클릭 시, `Moveable` 타겟 없어지도록 수정
* 수정 가능한 꾸미기 컴포넌트 조건 수정, 삭제 버튼 생성 조건 수정
* 수정된 페이지 데이터를 저장하지 않고 페이지 이동 혹은 추가 했을 시, 프로세스 추가
   - 꾸미기 컴포넌트 생성 혹은 수정 을 진행하던 도중, 페이지 이동 혹은 추가 을 시도할 시, 생성 혹은 수정을 완성하고 페이지 이동 혹은 추가 액션은 취소
   - 추가 혹은 수정된 꾸미기 컴포넌트 가 있지만 저장하지 않고, 페이지 이동 혹은 추가 를 시도할 시, 저장을 물어보는 `confirm` 창을 띄우고 확인 시, 페이지 저장, 취소 시 `updatedDecorateComponents` 비열을 비우고 페이지 이동 혹은 추가.
## 의논할 거리
- 꾸미기 컴포넌트 저장 조건 
## Merge 전에 해야할 작업
## 기타
