### PR TITLE
다일리 커뮤니티 좋아요, 정렬관련 기능 추가

### DIFF
--- a/frontend/src/apis/postApi.js
+++ b/frontend/src/apis/postApi.js
@@ -59,7 +59,7 @@ export const getPostsByHashtags = async (pageInfo) => {
   try {
     const { hashtags, page, size } = pageInfo;
     return await customAxios.get(
-      `/posts?hashtags=${hashtags}&page=${page}&size=${size}`,
+      `/posts/search?hashtags=${hashtags}&page=${page}&size=${size}`,
     );
   } catch (e) {
     console.error(e);

--- a/frontend/src/apis/postApi.js
+++ b/frontend/src/apis/postApi.js
@@ -91,3 +91,12 @@ export const getLikes = async (postIds) => {
     return e.response.data;
   }
 };
+
+export const getHotHashtags = async () => {
+  try {
+    return await customAxios.get('/posts/hotHashtags');
+  } catch (e) {
+    console.error(e);
+    return e.response.data;
+  }
+};

--- a/frontend/src/apis/postApi.js
+++ b/frontend/src/apis/postApi.js
@@ -45,6 +45,16 @@ export const getPosts = async (pageInfo) => {
   }
 };
 
+export const getHotPosts = async (pageInfo) => {
+  try {
+    const { page, size } = pageInfo;
+    return await customAxios.get(`/hotPosts?page=${page}&size=${size}`);
+  } catch (e) {
+    console.error(e);
+    return e.response.data;
+  }
+};
+
 export const deletePosts = async (postId) => {
   try {
     return await customAxios.delete(`posts/${postId}`);

--- a/frontend/src/apis/postApi.js
+++ b/frontend/src/apis/postApi.js
@@ -55,6 +55,18 @@ export const getHotPosts = async (pageInfo) => {
   }
 };
 
+export const getPostsByHashtags = async (pageInfo) => {
+  try {
+    const { hashtags, page, size } = pageInfo;
+    return await customAxios.get(
+      `/posts?hashtags=${hashtags}&page=${page}&size=${size}`,
+    );
+  } catch (e) {
+    console.error(e);
+    return e.response.data;
+  }
+};
+
 export const deletePosts = async (postId) => {
   try {
     return await customAxios.delete(`posts/${postId}`);

--- a/frontend/src/apis/postApi.js
+++ b/frontend/src/apis/postApi.js
@@ -71,3 +71,13 @@ export const deleteLikes = async (postId) => {
     return e.response.data;
   }
 };
+
+export const getLikes = async (postIds) => {
+  const postIdsQuery = postIds.map((postId) => `postIds=${postId}`).join('&');
+  try {
+    return await customAxios.get(`posts/likes?${postIdsQuery}`);
+  } catch (e) {
+    console.error(e);
+    return e.response.data;
+  }
+};

--- a/frontend/src/components/common/Navigation/CommunityNavigation.jsx
+++ b/frontend/src/components/common/Navigation/CommunityNavigation.jsx
@@ -1,16 +1,31 @@
+import { useEffect, useState } from 'react';
 import * as S from './Navigation.styled';
 import NameArea from './NameArea';
-// import Text from '../Text/Text';
-// import NavigationItem from '../NavigationItem/NavigationItem';
-// import { NavigationItemIcon } from '../../../assets/svg';
+import Text from '../Text/Text';
+import NavigationItem from '../NavigationItem/NavigationItem';
+import { NavigationItemIcon } from '../../../assets/svg';
+import { getHotHashtags } from '../../../apis/postApi';
 
 const CommunityNavigation = () => {
+  const [hotHashtags, setHotHashtags] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      const response = await getHotHashtags();
+      setHotHashtags(response.data.hashtags.map((hashtag) => hashtag.tagName));
+    })();
+  }, []);
+
   return (
     <S.NavigationWrapper>
       <NameArea />
       <S.Line />
-      {/* <Text css={S.ItemName}>Daily Hot</Text> */}
-      {/* <NavigationItem icon={<NavigationItemIcon />}>#수능</NavigationItem> */}
+      <Text css={S.ItemName}>Daily Hot</Text>
+      {hotHashtags.map((hashtag) => (
+        <NavigationItem icon={<NavigationItemIcon />} key={hashtag}>
+          #{hashtag}
+        </NavigationItem>
+      ))}
     </S.NavigationWrapper>
   );
 };

--- a/frontend/src/components/common/Navigation/CommunityNavigation.jsx
+++ b/frontend/src/components/common/Navigation/CommunityNavigation.jsx
@@ -1,20 +1,29 @@
 import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import * as S from './Navigation.styled';
 import NameArea from './NameArea';
 import Text from '../Text/Text';
 import NavigationItem from '../NavigationItem/NavigationItem';
 import { NavigationItemIcon } from '../../../assets/svg';
 import { getHotHashtags } from '../../../apis/postApi';
+import { PATH_NAME } from '../../../constants/routes';
 
 const CommunityNavigation = () => {
   const [hotHashtags, setHotHashtags] = useState([]);
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   useEffect(() => {
     (async () => {
       const response = await getHotHashtags();
       setHotHashtags(response.data.hashtags.map((hashtag) => hashtag.tagName));
+      setHotHashtags(['일반', '테스트', '태그']);
     })();
   }, []);
+
+  const handleTagClick = (hashtag) => {
+    navigate(`${PATH_NAME.CommunityList}?hashtag=${hashtag}`);
+  };
 
   return (
     <S.NavigationWrapper>
@@ -22,7 +31,12 @@ const CommunityNavigation = () => {
       <S.Line />
       <Text css={S.ItemName}>Daily Hot</Text>
       {hotHashtags.map((hashtag) => (
-        <NavigationItem icon={<NavigationItemIcon />} key={hashtag}>
+        <NavigationItem
+          current={hashtag === searchParams.get('hashtag')}
+          onClick={() => handleTagClick(hashtag)}
+          icon={<NavigationItemIcon />}
+          key={hashtag}
+        >
           #{hashtag}
         </NavigationItem>
       ))}

--- a/frontend/src/components/common/Navigation/CommunityNavigation.jsx
+++ b/frontend/src/components/common/Navigation/CommunityNavigation.jsx
@@ -17,7 +17,6 @@ const CommunityNavigation = () => {
     (async () => {
       const response = await getHotHashtags();
       setHotHashtags(response.data.hashtags.map((hashtag) => hashtag.tagName));
-      setHotHashtags(['일반', '테스트', '태그']);
     })();
   }, []);
 

--- a/frontend/src/constants/posts.js
+++ b/frontend/src/constants/posts.js
@@ -1,0 +1,22 @@
+import { getHotPosts, getPosts, getPostsByHashtags } from '../apis/postApi';
+
+export const POSTS_LOAD_CONDITIONS = [
+  {
+    parameter: 'hashtag',
+    check: (val) => val !== null,
+    getPosts: (param) => getPostsByHashtags(param),
+    post: 'posts',
+  },
+  {
+    parameter: 'orderBy',
+    check: (val) => val === 'latest',
+    getPosts: (param) => getPosts(param),
+    post: 'posts',
+  },
+  {
+    parameter: 'orderBy',
+    check: (val) => val === 'hotPosts',
+    getPosts: (param) => getHotPosts(param),
+    post: 'hotPosts',
+  },
+];

--- a/frontend/src/pages/CommunityPage/CommunityPage.jsx
+++ b/frontend/src/pages/CommunityPage/CommunityPage.jsx
@@ -81,16 +81,15 @@ const CommunityPage = () => {
     const { hasNext, [condition.post]: newPost, presentPage } = response.data;
     setPostState(hasNext, [...posts, ...newPost], presentPage + 1);
 
-    if (!memberId) {
-      return;
-    }
     const res = await getLikes([
       response.data[condition.post].map((p) => p.postId),
     ]);
-    setLiked({
-      ...liked,
-      ...(await res.data),
-    });
+    if (res.status === 200) {
+      setLiked({
+        ...liked,
+        ...(await res.data),
+      });
+    }
   };
 
   const onIntersect = (entries) => {

--- a/frontend/src/pages/CommunityPage/CommunityPage.jsx
+++ b/frontend/src/pages/CommunityPage/CommunityPage.jsx
@@ -69,9 +69,10 @@ const CommunityPage = () => {
   };
 
   const getSetPost = async () => {
-    const condition = conditions.find((c) => {
-      return c.value(searchParams.get(c.parameter));
-    });
+    const condition =
+      conditions.find((c) => {
+        return c.value(searchParams.get(c.parameter));
+      }) || conditions[1];
     const response = await condition.api();
     if (response.status !== 200) {
       toastify('알 수 없는 오류가 발생했습니다');

--- a/frontend/src/pages/CommunityPage/CommunityPage.jsx
+++ b/frontend/src/pages/CommunityPage/CommunityPage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { toast, Zoom } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
+import { toastify } from '../../utils/toastify';
 import * as S from './CommunityPage.styled';
 import {
   deletePosts,
@@ -25,16 +24,6 @@ const CommunityPage = () => {
   const [hasNextPage, setHasNextPage] = useState(true);
   const [liked, setLiked] = useState({});
   const navigate = useNavigate();
-
-  const toastify = (message) => {
-    toast(message, {
-      position: 'bottom-right',
-      autoClose: 300,
-      hideProgressBar: true,
-      closeOnClick: true,
-      transition: Zoom,
-    });
-  };
 
   const conditions = [
     {

--- a/frontend/src/pages/CommunityPage/CommunityPage.styled.jsx
+++ b/frontend/src/pages/CommunityPage/CommunityPage.styled.jsx
@@ -129,6 +129,10 @@ export const TagWrapper = styled.div`
   border-radius: 12px;
 `;
 
+export const TagDeleteButton = styled.button`
+  color: ${COMMUNITY.delete};
+`;
+
 export const WriteTagArea = styled.input`
   width: 120px;
   height: 30px;

--- a/frontend/src/pages/CommunityPage/CommunityPage.styled.jsx
+++ b/frontend/src/pages/CommunityPage/CommunityPage.styled.jsx
@@ -72,7 +72,7 @@ export const HeadWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: center;
+  align-items: start;
 
   width: 100%;
 `;
@@ -80,6 +80,7 @@ export const HeadWrapper = styled.div`
 export const RowFlex = styled.div`
   display: flex;
   flex-direction: row;
+  align-items: start;
   gap: 8px;
 `;
 

--- a/frontend/src/pages/CommunityPage/CommunityPage.styled.jsx
+++ b/frontend/src/pages/CommunityPage/CommunityPage.styled.jsx
@@ -63,7 +63,7 @@ export const PostWrapper = styled.div`
     background-color: ${COMMUNITY.line};
   }
 
-  &:last-child::after {
+  &:nth-last-child(-n + 2)::after {
     display: none;
   }
 `;

--- a/frontend/src/pages/CommunityPage/CommunityWritePage.jsx
+++ b/frontend/src/pages/CommunityPage/CommunityWritePage.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { toast, Zoom } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
+import { toastify } from '../../utils/toastify';
 import * as S from './CommunityPage.styled';
 import Button from '../../components/common/Button/Button';
 import Text from '../../components/common/Text/Text';
@@ -29,16 +28,6 @@ const CommunityWritePage = () => {
       }
     })();
   }, []);
-
-  const toastify = (message) => {
-    toast(message, {
-      position: 'bottom-right',
-      autoClose: 300,
-      hideProgressBar: true,
-      closeOnClick: true,
-      transition: Zoom,
-    });
-  };
 
   const handleContentChange = (e) => {
     setContent(e.target.value);

--- a/frontend/src/pages/CommunityPage/CommunityWritePage.jsx
+++ b/frontend/src/pages/CommunityPage/CommunityWritePage.jsx
@@ -108,7 +108,9 @@ const CommunityWritePage = () => {
         {[...hashtags].map((hashtag) => (
           <S.TagWrapper key={Math.random()}>
             <Text>#{hashtag}</Text>
-            <button onClick={() => handleTagDelClick(hashtag)}>x</button>
+            <S.TagDeleteButton onClick={() => handleTagDelClick(hashtag)}>
+              x
+            </S.TagDeleteButton>
           </S.TagWrapper>
         ))}
         <S.WriteTagArea

--- a/frontend/src/pages/DailryPage/DailryPage.jsx
+++ b/frontend/src/pages/DailryPage/DailryPage.jsx
@@ -2,9 +2,8 @@
 import { useState, useRef, useEffect } from 'react';
 import html2canvas from 'html2canvas';
 import saveAs from 'file-saver';
-import { toast, Zoom } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
 import { useNavigate } from 'react-router-dom';
+import { toastify } from '../../utils/toastify';
 import * as S from './DailryPage.styled';
 import Text from '../../components/common/Text/Text';
 import ToolButton from '../../components/da-ily/ToolButton/ToolButton';
@@ -157,16 +156,6 @@ const DailryPage = () => {
       }
     })();
   }, [pageIds, pageNumber]);
-
-  const toastify = (message) => {
-    toast(message, {
-      position: 'bottom-right',
-      autoClose: 300,
-      hideProgressBar: true,
-      closeOnClick: true,
-      transition: Zoom,
-    });
-  };
 
   const patchPageData = () => {
     setTarget(null);

--- a/frontend/src/pages/MyPage/MyPage.jsx
+++ b/frontend/src/pages/MyPage/MyPage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast, Zoom } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
+import { toastify } from '../../utils/toastify';
 import * as S from './MyPage.styled';
 import Button from '../../components/common/Button/Button';
 import Text from '../../components/common/Text/Text';
@@ -37,16 +36,6 @@ const MyPage = () => {
       setEmail(await response.data.email);
     })();
   }, []);
-
-  const toastify = (message) => {
-    toast(message, {
-      position: 'bottom-right',
-      autoClose: 300,
-      hideProgressBar: true,
-      closeOnClick: true,
-      transition: Zoom,
-    });
-  };
 
   const handleChangeNicknameClick = () => {
     setEditingNickname(true);

--- a/frontend/src/styles/color.js
+++ b/frontend/src/styles/color.js
@@ -73,5 +73,6 @@ export const COMMUNITY = Object.freeze({
   line: '#616161',
   noLike: '#9d9d9d',
   like: '#fb8d8d',
+  delete: '#ff0000',
   default: '#000000',
 });

--- a/frontend/src/utils/toastify.js
+++ b/frontend/src/utils/toastify.js
@@ -1,0 +1,15 @@
+import { toast, Zoom } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+export const toastify = (
+  message,
+  options = {
+    position: 'bottom-right',
+    autoClose: 300,
+    hideProgressBar: true,
+    closeOnClick: true,
+    transition: Zoom,
+  },
+) => {
+  toast(message, options);
+};


### PR DESCRIPTION
## 연관 이슈
close: #330
## 작업 내용
- 좋아요 누른 게시글 표시
- 최신게시글, 인기게시글 볼 수 있음
- 네비게이션에 핫 해시태그 노출
- 핫 해시태그 클릭시 태그로 검색
- 다일리 태그 작성시 x버튼 색 빨간색으로 변경
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
`CommunityPage`에 쿼리스트링별로 다른 api를 호출하기 위해 `conditions` 배열을 만들고, 조건을 만족하는 객체를 가져오게 만들었습니다. `conditions` 배열이나 `toastify` 함수를 따로 파일로 빼는게 깔끔할까요?